### PR TITLE
Add ability to shelve a data file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# S3-compatible storage credentials for Backblaze B2
+B2_APPLICATION_KEY_ID=your_application_key_id
+B2_APPLICATION_KEY=your_application_key
+B2_BUCKET_NAME=your_bucket_name

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # shelf
 A personal ETL and data lake.
+
+## Shelving a Data File
+
+To shelve a data file by adding it in a content-addressable way to the S3-compatible store, use the `shelve_data_file` function.
+
+### Usage
+
+1. Ensure you have configured your S3-compatible storage credentials in a `.env` file. You can use the provided `.env.example` as a template.
+
+2. Call the `shelve_data_file` function with the appropriate arguments:
+
+```python
+from shelf import shelve_data_file
+
+file_path = 'path/to/your/datafile.csv'
+namespace = 'your_namespace'
+dataset = 'your_dataset'
+version = 'v1'
+
+shelve_data_file(file_path, namespace, dataset, version)
+```
+
+This will:
+- Generate a checksum for the file.
+- Upload the file to the S3-compatible store using the checksum as the key.
+- Create a metadata record in the `metadata` directory with the checksum and other details.
+
+## Command Line Usage
+
+You can also use the `shelve` command from the command line to shelve a data file.
+
+### Usage
+
+1. Ensure you have configured your S3-compatible storage credentials in a `.env` file. You can use the provided `.env.example` as a template.
+
+2. Run the `shelve` command with the appropriate arguments:
+
+```sh
+shelve path/to/your/datafile.csv your_namespace your_dataset
+```
+
+or
+
+```sh
+shelve path/to/your/datafile.csv your_namespace your_dataset your_version
+```
+
+This will:
+- Generate a checksum for the file.
+- Upload the file to the S3-compatible store using the checksum as the key.
+- Create a metadata record in the `metadata` directory with the checksum and other details.
+- Copy the file to the `data` directory with the same structure as the metadata directory, keeping its original extension.

--- a/metadata/example.yaml
+++ b/metadata/example.yaml
@@ -1,0 +1,4 @@
+namespace: example_namespace
+dataset: example_dataset
+version: example_version
+checksum: example_checksum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/shelf"]
+
+[tool.poetry.scripts]
+shelve = "shelf:main"

--- a/src/shelf/__init__.py
+++ b/src/shelf/__init__.py
@@ -1,2 +1,74 @@
-def hello() -> str:
-    return "Hello from shelf!"
+import os
+import hashlib
+import boto3
+import yaml
+from dotenv import load_dotenv
+import argparse
+from datetime import datetime
+import shutil
+
+load_dotenv()
+
+def shelve_data_file(file_path: str, namespace: str, dataset: str, version: str = None) -> None:
+    if version is None:
+        version = datetime.today().strftime('%Y-%m-%d')
+
+    # Generate checksum for the file
+    checksum = generate_checksum(file_path)
+
+    # Upload file to S3-compatible store
+    upload_to_s3(file_path, checksum)
+
+    # Create metadata record
+    metadata = {
+        'namespace': namespace,
+        'dataset': dataset,
+        'version': version,
+        'checksum': checksum,
+        'extension': os.path.splitext(file_path)[1]
+    }
+
+    # Save metadata record to YAML file
+    save_metadata(metadata, namespace, dataset, version)
+
+    # Copy file to data directory
+    copy_to_data_dir(file_path, namespace, dataset, version)
+
+def generate_checksum(file_path: str) -> str:
+    sha256 = hashlib.sha256()
+    with open(file_path, 'rb') as f:
+        for block in iter(lambda: f.read(4096), b''):
+            sha256.update(block)
+    return sha256.hexdigest()
+
+def upload_to_s3(file_path: str, checksum: str) -> None:
+    s3 = boto3.client('s3')
+    bucket_name = os.getenv('B2_BUCKET_NAME')
+    s3.upload_file(file_path, bucket_name, checksum)
+
+def save_metadata(metadata: dict, namespace: str, dataset: str, version: str) -> None:
+    metadata_dir = os.path.join('metadata', namespace, dataset)
+    os.makedirs(metadata_dir, exist_ok=True)
+    metadata_file = os.path.join(metadata_dir, f'{version}.yaml')
+    with open(metadata_file, 'w') as f:
+        yaml.dump(metadata, f)
+
+def copy_to_data_dir(file_path: str, namespace: str, dataset: str, version: str) -> None:
+    data_dir = os.path.join('data', namespace, dataset)
+    os.makedirs(data_dir, exist_ok=True)
+    file_extension = os.path.splitext(file_path)[1]
+    data_file = os.path.join(data_dir, f'{version}{file_extension}')
+    shutil.copy2(file_path, data_file)
+
+def main():
+    parser = argparse.ArgumentParser(description='Shelve a data file by adding it in a content-addressable way to the S3-compatible store.')
+    parser.add_argument('file_path', type=str, help='Path to the data file')
+    parser.add_argument('namespace', type=str, help='Namespace for the data file')
+    parser.add_argument('dataset', type=str, help='Dataset for the data file')
+    parser.add_argument('version', type=str, nargs='?', help='Version of the data file (optional, defaults to today\'s date)')
+    args = parser.parse_args()
+
+    shelve_data_file(args.file_path, args.namespace, args.dataset, args.version)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Related to #1

Add the ability to shelve a data file by adding it in a content-addressable way to the S3-compatible store.

* Add `shelve_data_file` function in `src/shelf/__init__.py` to handle shelving data files.
  - Generate a checksum for the file.
  - Upload the file to the S3-compatible store using the checksum as the key.
  - Create a metadata record in the `metadata` directory with the checksum and other details.
  - Copy the file to the `data` directory with the same structure as the metadata directory, keeping its original extension.
* Add command-line interface for shelving data files.
  - Support `--help` and flexible command-line arguments.
  - Default version to today's date if not provided.
* Add `metadata/example.yaml` as a sample YAML file.
* Update `README.md` to include instructions on how to use the new shelving command.
* Add the new command to `pyproject.toml` with the alias `shelve`.
* Add `.env.example` file to indicate how to configure the S3-compatible storage credentials, suitable for Backblaze B2.
* Add `.env` file to pick up credentials and other needed environment variables.
* Create the directory `metadata` and `.gitignore` the `data/` folder.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/larsyencken/shelf/issues/1?shareId=26062096-2bdb-4c32-9358-d4dfbf084ed2).