### PR TITLE
Update shelve command to take two parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,9 @@ To shelve a data file by adding it in a content-addressable way to the S3-compat
 from shelf import shelve_data_file
 
 file_path = 'path/to/your/datafile.csv'
-namespace = 'your_namespace'
-dataset = 'your_dataset'
-version = 'v1'
+path = 'your_namespace/your_dataset/your_version'
 
-shelve_data_file(file_path, namespace, dataset, version)
+shelve_data_file(file_path, path)
 ```
 
 This will:
@@ -38,13 +36,13 @@ You can also use the `shelve` command from the command line to shelve a data fil
 2. Run the `shelve` command with the appropriate arguments:
 
 ```sh
-shelve path/to/your/datafile.csv your_namespace your_dataset
+shelve path/to/your/datafile.csv your_namespace/your_dataset
 ```
 
 or
 
 ```sh
-shelve path/to/your/datafile.csv your_namespace your_dataset your_version
+shelve path/to/your/datafile.csv your_namespace/your_dataset/your_version
 ```
 
 This will:

--- a/src/shelf/__init__.py
+++ b/src/shelf/__init__.py
@@ -9,9 +9,15 @@ import shutil
 
 load_dotenv()
 
-def shelve_data_file(file_path: str, namespace: str, dataset: str, version: str = None) -> None:
-    if version is None:
+def shelve_data_file(file_path: str, path: str) -> None:
+    parts = path.split('/')
+    if len(parts) == 2:
+        namespace, dataset = parts
         version = datetime.today().strftime('%Y-%m-%d')
+    elif len(parts) == 3:
+        namespace, dataset, version = parts
+    else:
+        raise ValueError("Path must be in the format 'namespace/dataset' or 'namespace/dataset/version'")
 
     # Generate checksum for the file
     checksum = generate_checksum(file_path)
@@ -63,12 +69,10 @@ def copy_to_data_dir(file_path: str, namespace: str, dataset: str, version: str)
 def main():
     parser = argparse.ArgumentParser(description='Shelve a data file by adding it in a content-addressable way to the S3-compatible store.')
     parser.add_argument('file_path', type=str, help='Path to the data file')
-    parser.add_argument('namespace', type=str, help='Namespace for the data file')
-    parser.add_argument('dataset', type=str, help='Dataset for the data file')
-    parser.add_argument('version', type=str, nargs='?', help='Version of the data file (optional, defaults to today\'s date)')
+    parser.add_argument('path', type=str, help='Path in the format namespace/dataset or namespace/dataset/version')
     args = parser.parse_args()
 
-    shelve_data_file(args.file_path, args.namespace, args.dataset, args.version)
+    shelve_data_file(args.file_path, args.path)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Related to #1

Add ability to shelve a data file by adding it in a content-addressable way to the S3-compatible store.

* **Update `shelve_data_file` function**: Modify the function to take two parameters: `filename` and `path`. Parse the `path` parameter to extract `namespace`, `dataset`, and optionally `version`.
* **Update `main` function**: Modify the `main` function to parse the new `path` parameter structure.
* **Update `README.md`**: Reflect the new parameter structure in the usage instructions for both the `shelve_data_file` function and the `shelve` command line tool.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/larsyencken/shelf/issues/1?shareId=21491a12-5884-4c26-b035-331eb37c3d8b).