### PR TITLE
Add the ability to shelve and unpack directories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # S3-compatible storage credentials for Backblaze B2
-B2_APPLICATION_KEY_ID=your_application_key_id
-B2_APPLICATION_KEY=your_application_key
-B2_BUCKET_NAME=your_bucket_name
-B2_ENDPOINT_URL=your_endpoint_url
+S3_ACCESS_KEY=your_application_key_id
+S3_SECRET_KEY=your_application_key
+S3_BUCKET_NAME=your_bucket_name
+S3_ENDPOINT_URL=your_endpoint_url
+
+TEST_ACCESS_KEY=
+TEST_SECRET_KEY=
+TEST_ENDPOINT_URL=
+TEST_BUCKET_NAME=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      minio:
+        image: lazybit/minio
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ACCESS_KEY: justtesting
+          MINIO_SECRET_KEY: justtesting
+        options: --name=minio --health-cmd "curl http://localhost:9000/minio/health/live"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -27,5 +37,26 @@ jobs:
       - name: Install dependencies
         run: make .venv
 
+      - name: Set up testing minio bucket
+        run: |
+          .venv/bin/python3 - <<'EOF'
+          from minio import Minio
+
+          minio = Minio(
+              'localhost:9000',
+              access_key='justtesting',
+              secret_key='justtesting',
+              secure=False
+          )
+
+          minio.make_bucket('test')
+          print(f'{minio.list_buckets()}')
+          EOF
+
       - name: Run tests
         run: make test
+        env:
+          B2_APPLICATION_KEY: justtesting
+          B2_APPLICATION_KEY_ID: justtesting
+          B2_BUCKET_NAME: test
+          B2_ENDPOINT_URL: http://localhost:9000/

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 
 data/
+metadata/

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ unittest: .venv
 format: .venv
 	@echo "==> Formatting all files"
 	@rye format
+	@rye lint --fix
 
 # Lint using rye
 lint: .venv
@@ -36,3 +37,6 @@ typecheck: .venv
 
 # Run lint, typecheck, and unittest sequentially
 test: lint typecheck unittest
+
+clean:
+	rm -rf data/* metadata/*

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # shelf
+
 A personal ETL and data lake.
+
+## Overview
+
+Shelf is a personal ETL framework for managing small data files and directories in a content-addressable way.
 
 ## Shelving a Data File
 
-To shelve a data file by adding it in a content-addressable way to the S3-compatible store, use the `shelve_data_file` function.
+To shelve a data file by adding it in a content-addressable way to the S3-compatible store, use the `shelf add` function.
 
 ### Usage
 
 1. Ensure you have configured your S3-compatible storage credentials in a `.env` file. You can use the provided `.env.example` as a template.
 
-2. Call the `shelve_data_file` function with the appropriate arguments:
+2. Call the `shelf add` function with the appropriate arguments:
 
 ```python
 from shelf import shelve_data_file
@@ -21,35 +26,93 @@ shelve_data_file(file_path, path)
 ```
 
 This will:
+
 - Generate a checksum for the file.
 - Upload the file to the S3-compatible store using the checksum as the key.
 - Create a metadata record in the `metadata` directory with the checksum and other details.
 - Open the metadata file in an interactive editor for editing.
 
-## Command Line Usage
+## Shelving a Directory
 
-You can also use the `shelve` command from the command line to shelve a data file.
+To shelve a directory by adding all its files in a content-addressable way to the S3-compatible store, use the `shelf add` function.
 
 ### Usage
 
 1. Ensure you have configured your S3-compatible storage credentials in a `.env` file. You can use the provided `.env.example` as a template.
 
-2. Run the `shelve` command with the appropriate arguments:
+2. Call the `shelf add` function with the appropriate arguments:
+
+```python
+from shelf import shelve_data_file
+
+directory_path = 'path/to/your/directory'
+path = 'your_namespace/your_dataset/your_version'
+
+shelve_data_file(directory_path, path)
+```
+
+This will:
+
+- Generate a checksum for each file in the directory.
+- Upload each file to the S3-compatible store using the checksum as the key.
+- Create a manifest file containing the directory listing and shelve it.
+- Create a metadata record in the `metadata` directory indicating that it's a directory being unpacked.
+- Open the metadata file in an interactive editor for editing.
+
+## Command Line Usage
+
+You can also use the `shelf` command from the command line to shelve a data file or directory.
+
+### Usage
+
+1. Ensure you have configured your S3-compatible storage credentials in a `.env` file. You can use the provided `.env.example` as a template.
+
+2. Run the `shelf add` command with the appropriate arguments:
 
 ```sh
-shelve path/to/your/datafile.csv your_namespace/your_dataset
+shelf add path/to/your/datafile.csv your_namespace/your_dataset
 ```
 
 or
 
 ```sh
-shelve path/to/your/datafile.csv your_namespace/your_dataset/your_version
+shelf add path/to/your/datafile.csv your_namespace/your_dataset/your_version
+```
+
+or
+
+```sh
+shelf add path/to/your/directory your_namespace/your_dataset/your_version
 ```
 
 This will:
-- Generate a checksum for the file.
-- Upload the file to the S3-compatible store using the checksum as the key.
+
+- Generate a checksum for the file or each file in the directory.
+- Upload the file or each file in the directory to the S3-compatible store using the checksum as the key.
+- Create a manifest file containing the directory listing and shelve it (if a directory is provided).
 - Create a metadata record in the `metadata` directory with the checksum and other details.
-- Print a message indicating the file is being shelved.
+- Print a message indicating the file or directory is being shelved.
 - Open the metadata file in an interactive editor for editing.
-- Copy the file to the `data` directory with the same structure as the metadata directory, keeping its original extension.
+- Copy the file or directory to the `data` directory with the same structure as the metadata directory, keeping its original extension.
+
+## Restoring Data
+
+To restore data from the content store and unpack it into the `data/` folder, use the `shelf get` command.
+
+### Usage
+
+1. Ensure you have configured your S3-compatible storage credentials in a `.env` file. You can use the provided `.env.example` as a template.
+
+2. Run the `shelf get` command with the appropriate arguments:
+
+```sh
+shelf get [optional_regex]
+```
+
+This will:
+
+- Fetch things from the content store and unpack them into `data/`.
+- If an optional regex argument is provided, it will match against metadata path names to determine what to include.
+- If no argument is provided, it will walk the `metadata/` folder and fetch everything.
+- Only re-fetch things whose local checksum in the `data/` folder is out of date.
+- Restore directories (and their subdirectories) from the content store.

--- a/metadata/example/example/2024-07-20.yaml
+++ b/metadata/example/example/2024-07-20.yaml
@@ -1,6 +1,0 @@
-checksum: ff0b52e4d4b596833d898f38c9ddc6936f5cc615fb6c6eee2505d9c931ccc522
-dataset: example
-extension: .csv
-namespace: example
-version: '2024-07-20'
-title: Test CSV file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,7 @@
 name = "shelf"
 version = "0.1.0"
 description = "Add your description here"
-authors = [
-    { name = "Lars Yencken", email = "lars@yencken.org" }
-]
+authors = [{ name = "Lars Yencken", email = "lars@yencken.org" }]
 dependencies = [
     "boto3>=1.34.145",
     "pyyaml>=6.0.1",
@@ -15,7 +13,7 @@ readme = "README.md"
 requires-python = ">= 3.12"
 
 [project.scripts]
-shelve = "shelf:main"
+shelf = "shelf:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -23,9 +21,7 @@ build-backend = "hatchling.build"
 
 [tool.rye]
 managed = true
-dev-dependencies = [
-    "pytest>=8.3.1",
-]
+dev-dependencies = ["pytest>=8.3.1", "minio>=7.2.7"]
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,22 +10,35 @@
 #   universal: false
 
 -e file:.
+argon2-cffi==23.1.0
+    # via minio
+argon2-cffi-bindings==21.2.0
+    # via argon2-cffi
 boto3==1.34.145
     # via shelf
 botocore==1.34.145
     # via boto3
     # via s3transfer
+certifi==2024.7.4
+    # via minio
+cffi==1.16.0
+    # via argon2-cffi-bindings
 iniconfig==2.0.0
     # via pytest
 jmespath==1.0.1
     # via boto3
     # via botocore
+minio==7.2.7
 nodeenv==1.9.1
     # via pyright
 packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
+pycparser==2.22
+    # via cffi
+pycryptodome==3.20.0
+    # via minio
 pyright==1.1.372
     # via shelf
 pytest==8.3.1
@@ -39,5 +52,8 @@ s3transfer==0.10.2
     # via boto3
 six==1.16.0
     # via python-dateutil
+typing-extensions==4.12.2
+    # via minio
 urllib3==2.2.2
     # via botocore
+    # via minio

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,2 +1,0 @@
-def test_example():
-    pass

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -1,0 +1,102 @@
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from shelf import add, get  # noqa
+
+BASE = Path(__file__).parent.parent
+DATA_DIR = BASE / "data"
+METADATA_DIR = BASE / "metadata"
+
+
+@pytest.fixture
+def setup_test_environment(tmp_path):
+    # Setup temporary environment for testing
+    os.environ["S3_ACCESS_KEY"] = os.environ.get("TEST_ACCESS_KEY", "justtesting")
+    os.environ["S3_SECRET_KEY"] = os.environ.get("TEST_SECRET_KEY", "justtesting")
+    os.environ["S3_BUCKET_NAME"] = os.environ.get("TEST_BUCKET_NAME", "test")
+    os.environ["S3_ENDPOINT_URL"] = os.environ.get(
+        "TEST_ENDPOINT_URL", "http://localhost:9000"
+    )
+
+    # Create test directory and files
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    yield test_dir
+
+    # Cleanup
+    shutil.rmtree(test_dir)
+
+
+def test_add_file(setup_test_environment):
+    tmp_path = setup_test_environment
+
+    # configure test
+    path = "test_namespace/test_dataset/2024-07-26"
+    data_file = DATA_DIR / "test_namespace" / "test_dataset" / "2024-07-26.txt"
+    metadata_file = METADATA_DIR / "test_namespace" / "test_dataset" / "2024-07-26.yaml"
+
+    # make sure files are clear from previous runs
+    data_file.unlink(missing_ok=True)
+    metadata_file.unlink(missing_ok=True)
+
+    # create dummy file
+    new_file = tmp_path / "file1.txt"
+    new_file.write_text("Hello, World!")
+
+    # add file to shelf
+    add(str(new_file), path)
+
+    # check for data and metadata
+    assert data_file.exists()
+    assert metadata_file.exists()
+
+    # re-fectch it from shelf
+    data_file.unlink()
+    get("test_namespace/test_dataset/2024-07-26")
+    assert data_file.exists()
+    assert data_file.read_text() == "Hello, World!"
+
+
+def test_shelve_directory(setup_test_environment):
+    tmp_path = setup_test_environment
+
+    # configure test
+    path = "test_namespace/test_dataset/test_version"
+    data_path = DATA_DIR / path
+    metadata_file = (METADATA_DIR / path).with_suffix(".yaml")
+
+    # clear from previous runs
+    if data_path.exists():
+        shutil.rmtree(data_path)
+    metadata_file.unlink(missing_ok=True)
+
+    # create dummy data
+    parent = tmp_path / "example"
+    if parent.exists():
+        shutil.rmtree(parent)
+    parent.mkdir()
+    (parent / "file1.txt").write_text("Hello, World!")
+    (parent / "file2.txt").write_text("Hello, Cosmos!")
+
+    # add to shelf
+    add(str(parent), path)
+
+    # check the right local files are created
+    assert data_path.is_dir()
+    assert metadata_file.exists()
+    assert (data_path / "MANIFEST.yaml").exists()
+
+    # clear the data
+    shutil.rmtree(data_path)
+
+    # restore from shelf
+    get(path)
+
+    # check it got restored
+    assert data_path.is_dir()
+    assert (data_path / "file1.txt").exists()
+    assert (data_path / "file2.txt").exists()
+    assert (data_path / "MANIFEST.yaml").exists()


### PR DESCRIPTION
Related to #10

Add support for shelving and restoring directories in the `shelf` command.

* **Update `README.md`**:
  - Update instructions to include shelving and restoring directories.
  - Rename `shelve` command to `shelf` and update usage examples.

* **Modify `src/shelf/__init__.py`**:
  - Update `shelve_data_file` function to handle directories and subdirectories.
  - Add `add_directory_to_shelf` and `add_file_to_shelf` functions to handle directories and individual files respectively.
  - Add `restore` function to fetch and unpack directories from the content store.
  - Update `main` function to support `shelf add` and `shelf get` subcommands.

* **Add tests in `tests/test_example.py`**:
  - Add tests for shelving directories.
  - Add tests for restoring directories.
  - Use pytest fixtures to set up and clean up the test environment.

## Todo

- [x] Get tests working in CI for `shelf add <file>`
- [x] Add tests for `shelf add <directory>`


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/larsyencken/shelf/issues/10?shareId=66acc40d-bb21-49bc-9392-76eb955796e9).