### PR TITLE
Add a `shelf list` command that lists all datasets

### DIFF
--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -199,8 +199,8 @@ def test_list_datasets(setup_test_environment):
     add(str(new_file2), path2)
 
     # capture the output of list_datasets
-    from io import StringIO
     import sys
+    from io import StringIO
 
     captured_output = StringIO()
     sys.stdout = captured_output
@@ -209,8 +209,8 @@ def test_list_datasets(setup_test_environment):
 
     output = captured_output.getvalue().strip().split("\n")
     assert output == [
-        "test_namespace/test_dataset1/2024-07-26.meta.yaml",
-        "test_namespace/test_dataset2/2024-07-27.meta.yaml",
+        "test_namespace/test_dataset1/2024-07-26",
+        "test_namespace/test_dataset2/2024-07-27",
     ]
 
 
@@ -231,8 +231,8 @@ def test_list_datasets_with_regex(setup_test_environment):
     add(str(new_file2), path2)
 
     # capture the output of list_datasets with regex
-    from io import StringIO
     import sys
+    from io import StringIO
 
     captured_output = StringIO()
     sys.stdout = captured_output
@@ -240,4 +240,4 @@ def test_list_datasets_with_regex(setup_test_environment):
     sys.stdout = sys.__stdout__
 
     output = captured_output.getvalue().strip().split("\n")
-    assert output == ["test_namespace/test_dataset1/2024-07-26.meta.yaml"]
+    assert output == ["test_namespace/test_dataset1/2024-07-26"]


### PR DESCRIPTION
Related to #15

Add a `shelf list` command to list all datasets in alphabetical order and filter by regex.

* **src/shelf/__init__.py**
  - Implement the `list_datasets` function to list all datasets in alphabetical order and filter by an optional regex argument.
  - Add a new `list` command to the `main` function to call the `list_datasets` function.
  - Update the argument parser to include the `list` command with an optional regex argument.

* **tests/test_shelf.py**
  - Add a test for the `list` command to verify it lists all datasets.
  - Add a test for the `list` command to verify it filters datasets based on regex.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/larsyencken/shelf/issues/15?shareId=16a6bdd6-6407-4340-a3db-cbe5205041e3).