### PR TITLE
Fix YAML keys order in metadata files

### DIFF
--- a/src/shelf/core.py
+++ b/src/shelf/core.py
@@ -46,6 +46,8 @@ class Shelf:
                         "data_dir": "data",
                         "steps": {},
                     },
+                    Dumper=yaml.Dumper,
+                    default_flow_style=False,
                 )
             )
         else:
@@ -62,4 +64,6 @@ class Shelf:
         }
         jsonschema.validate(config, SHELF_SCHEMA)
         print_op("UPDATE", self.config_file)
-        self.config_file.write_text(yaml.safe_dump(config))
+        self.config_file.write_text(
+            yaml.safe_dump(config, Dumper=yaml.Dumper, default_flow_style=False)
+        )

--- a/src/shelf/snapshots.py
+++ b/src/shelf/snapshots.py
@@ -108,7 +108,9 @@ class Snapshot:
             print_op("UPDATE", self.metadata_path)
 
         self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
-        self.metadata_path.write_text(yaml.safe_dump(record))
+        self.metadata_path.write_text(
+            yaml.safe_dump(record, Dumper=yaml.Dumper, default_flow_style=False)
+        )
 
     def to_dict(self) -> dict:
         record = asdict(self)

--- a/src/shelf/tables.py
+++ b/src/shelf/tables.py
@@ -106,7 +106,7 @@ def _gen_metadata(uri: StepURI, dependencies: list[StepURI]) -> None:
             f"Table {uri} does not have any dimension columns prefixed with dim_"
         )
 
-    dest_path.write_text(yaml.safe_dump(metadata))
+    dest_path.write_text(yaml.safe_dump(metadata, Dumper=yaml.Dumper, default_flow_style=False))
 
 
 def _generate_input_manifest(uri: StepURI, dependencies: list[StepURI]) -> Manifest:


### PR DESCRIPTION
Related to #32

Update YAML dumping to preserve key order in metadata files.

* **src/shelf/core.py**
  - Update `yaml.safe_dump` in `Shelf.init` and `Shelf.save` methods to use `Dumper=yaml.Dumper` with `default_flow_style=False`.

* **src/shelf/snapshots.py**
  - Update `yaml.safe_dump` in `Snapshot.save` method to use `Dumper=yaml.Dumper` with `default_flow_style=False`.

* **src/shelf/tables.py**
  - Update `yaml.safe_dump` in `_gen_metadata` function to use `Dumper=yaml.Dumper` with `default_flow_style=False`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/larsyencken/shelf/issues/32?shareId=98f54b66-c674-4109-ad74-eb51fa2e550a).