### PR TITLE
Use .data-files for alcove data ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ Please report any issues at: https://github.com/larsyencken/alcove/issues
   - Improved documentation with quick start guide and command reference
 
 - `dev` (unreleased)
+  - Added `.data-files` file for managing alcove data ignores (#61)
+  - `alcove init` now creates empty `.data-files` and ensures it's in `.gitignore`
+  - `alcove audit --fix` can move patterns from `.gitignore` to `.data-files`
+  - Prevents `.gitignore` from changing frequently with data file updates
 
 - `0.1.1` (2025-04-25)
   - Renamed project from "shelf" to "alcove"

--- a/src/alcove/utils.py
+++ b/src/alcove/utils.py
@@ -53,7 +53,61 @@ def print_op(type_: str, message: Any) -> None:
     console.print(f"[blue]{type_:>15}[/blue]   {message}")
 
 
+def add_to_data_files(path: Path) -> None:
+    """
+    Add a path to the .data-files file, creating it if it doesn't exist.
+    Also ensure .gitignore includes .data-files.
+    """
+    data_files = Path(".data-files")
+    path_str = str(path.relative_to(BASE_DIR))
+
+    # First ensure .data-files is included in .gitignore
+    ensure_data_files_in_gitignore()
+
+    # Then add the path to .data-files
+    if data_files.exists():
+        with open(data_files) as f:
+            entries = set(line.strip() for line in f if line.strip())
+
+        if path_str in entries:
+            # it's already here
+            return
+
+        print_op("UPDATE", ".data-files")
+    else:
+        print_op("CREATE", ".data-files")
+
+    with data_files.open("a") as f:
+        print(path_str, file=f)
+
+
+def ensure_data_files_in_gitignore() -> None:
+    """
+    Ensure that .gitignore includes a reference to .data-files.
+    """
+    gitignore = Path(".gitignore")
+    
+    if gitignore.exists():
+        with open(gitignore) as f:
+            entries = set(line.strip() for line in f if line.strip())
+        
+        if ".data-files" in entries:
+            # Reference already exists
+            return
+            
+        print_op("UPDATE", ".gitignore")
+    else:
+        print_op("CREATE", ".gitignore")
+    
+    with gitignore.open("a") as f:
+        print(".data-files", file=f)
+
+
 def add_to_gitignore(path: Path) -> None:
+    """
+    Legacy function to add a path directly to .gitignore.
+    This will be phased out in favor of add_to_data_files.
+    """
     gitignore = Path(".gitignore")
     path_str = str(path.relative_to(BASE_DIR))
 

--- a/src/alcove/utils.py
+++ b/src/alcove/utils.py
@@ -53,10 +53,54 @@ def print_op(type_: str, message: Any) -> None:
     console.print(f"[blue]{type_:>15}[/blue]   {message}")
 
 
+def add_entry_to_file(file_path: Path, entry: str) -> None:
+    """
+    Add an entry to a file if it doesn't already exist.
+    
+    Args:
+        file_path: The path to the file to add the entry to
+        entry: The string to add to the file
+    """
+    if file_path.exists():
+        with open(file_path) as f:
+            entries = set(line.strip() for line in f if line.strip())
+
+        if entry in entries:
+            # Entry already exists, nothing to do
+            return
+
+        print_op("UPDATE", str(file_path.name))
+    else:
+        print_op("CREATE", str(file_path.name))
+
+    with file_path.open("a") as f:
+        print(entry, file=f)
+
+
+def ensure_data_files_in_gitignore() -> None:
+    """
+    Ensure that .gitignore includes a reference to .data-files.
+    Creates both files if they don't exist.
+    """
+    gitignore = Path(".gitignore")
+    data_files = Path(".data-files")
+    
+    # Create empty .data-files if it doesn't exist
+    if not data_files.exists():
+        data_files.touch()
+        print_op("CREATE", ".data-files")
+    
+    # Add .data-files reference to .gitignore
+    add_entry_to_file(gitignore, ".data-files")
+
+
 def add_to_data_files(path: Path) -> None:
     """
     Add a path to the .data-files file, creating it if it doesn't exist.
     Also ensure .gitignore includes .data-files.
+    
+    Args:
+        path: The path to add to .data-files
     """
     data_files = Path(".data-files")
     path_str = str(path.relative_to(BASE_DIR))
@@ -65,66 +109,22 @@ def add_to_data_files(path: Path) -> None:
     ensure_data_files_in_gitignore()
 
     # Then add the path to .data-files
-    if data_files.exists():
-        with open(data_files) as f:
-            entries = set(line.strip() for line in f if line.strip())
-
-        if path_str in entries:
-            # it's already here
-            return
-
-        print_op("UPDATE", ".data-files")
-    else:
-        print_op("CREATE", ".data-files")
-
-    with data_files.open("a") as f:
-        print(path_str, file=f)
-
-
-def ensure_data_files_in_gitignore() -> None:
-    """
-    Ensure that .gitignore includes a reference to .data-files.
-    """
-    gitignore = Path(".gitignore")
-    
-    if gitignore.exists():
-        with open(gitignore) as f:
-            entries = set(line.strip() for line in f if line.strip())
-        
-        if ".data-files" in entries:
-            # Reference already exists
-            return
-            
-        print_op("UPDATE", ".gitignore")
-    else:
-        print_op("CREATE", ".gitignore")
-    
-    with gitignore.open("a") as f:
-        print(".data-files", file=f)
+    add_entry_to_file(data_files, path_str)
 
 
 def add_to_gitignore(path: Path) -> None:
     """
     Legacy function to add a path directly to .gitignore.
     This will be phased out in favor of add_to_data_files.
+    
+    Args:
+        path: The path to add to .gitignore
     """
     gitignore = Path(".gitignore")
     path_str = str(path.relative_to(BASE_DIR))
 
-    if gitignore.exists():
-        with open(gitignore) as f:
-            entries = set(line.strip() for line in f if line.strip())
-
-        if path_str in entries:
-            # it's already here
-            return
-
-        print_op("UPDATE", ".gitignore")
-    else:
-        print_op("CREATE", ".gitignore")
-
-    with gitignore.open("a") as f:
-        print(path_str, file=f)
+    # Add the path to .gitignore
+    add_entry_to_file(gitignore, path_str)
 
 
 def dump_yaml_with_comments(obj: dict, f) -> None:

--- a/tests/test_alcove.py
+++ b/tests/test_alcove.py
@@ -55,6 +55,7 @@ def test_add_file(setup_test_environment):
         / "2024-07-26.meta.yaml"
     )
     gitignore_file = tmp_path / ".gitignore"
+    data_files_file = tmp_path / ".data-files"
     shelf_yaml_file = tmp_path / "alcove.yaml"
 
     # create dummy file
@@ -69,9 +70,12 @@ def test_add_file(setup_test_environment):
     assert data_file.exists()
     assert metadata_file.exists()
 
-    # check if data path is added to .gitignore
+    # check if data path is added to .data-files and .gitignore includes .data-files
     assert gitignore_file.exists()
+    assert data_files_file.exists()
     with open(gitignore_file, "r") as f:
+        assert ".data-files" in f.read()
+    with open(data_files_file, "r") as f:
         assert f"data/snapshots/{uri.path}.txt\n" in f.read()
 
     # check if dataset name is added to shelf.yaml under steps
@@ -111,6 +115,7 @@ def test_shelve_directory(setup_test_environment):
     data_path = tmp_path / "data/snapshots/" / path
     metadata_file = (tmp_path / "data/snapshots" / path).with_suffix(".meta.yaml")
     gitignore_file = tmp_path / ".gitignore"
+    data_files_file = tmp_path / ".data-files"
     shelf_yaml_file = tmp_path / "alcove.yaml"
 
     # create dummy data
@@ -131,9 +136,12 @@ def test_shelve_directory(setup_test_environment):
     metadata = load_yaml(metadata_file)
     assert metadata.get("manifest")
 
-    # check if data path is added to .gitignore
+    # check if data path is added to .data-files and .gitignore includes .data-files
     assert gitignore_file.exists()
+    assert data_files_file.exists()
     with open(gitignore_file, "r") as f:
+        assert ".data-files" in f.read()
+    with open(data_files_file, "r") as f:
         assert f"{path}\n" in f.read()
 
     # check if dataset name is added to shelf.yaml under steps

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,162 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from alcove import audit_gitignore_setup
+from alcove.utils import add_to_gitignore, add_to_data_files, ensure_data_files_in_gitignore
+
+
+def test_gitignore_simple():
+    """Test basic functionality of add_to_gitignore"""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        tmp_path = Path(tmp)
+        
+        # Mock BASE_DIR to be our temporary directory
+        with mock.patch('alcove.utils.BASE_DIR', tmp_path):
+            # Create a temporary path structure
+            data_dir = tmp_path / "data" / "test"
+            data_dir.mkdir(parents=True)
+            test_file = data_dir / "path"
+            test_file.touch()
+            
+            # Test with non-existent .gitignore
+            add_to_gitignore(test_file)
+            
+            # Check the file was created with the right entry
+            gitignore_path = tmp_path / ".gitignore"
+            assert gitignore_path.exists()
+            content = gitignore_path.read_text().strip()
+            assert content == "data/test/path"
+            
+            # Test adding a second entry
+            test_file2 = data_dir / "another" / "path"
+            test_file2.parent.mkdir(parents=True)
+            test_file2.touch()
+            add_to_gitignore(test_file2)
+            
+            # Check the new entry was added
+            content = gitignore_path.read_text().strip().split('\n')
+            assert "data/test/path" in content
+            assert "data/test/another/path" in content
+
+
+def test_gitignore_existing_entry():
+    """Test add_to_gitignore with an already existing entry"""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        tmp_path = Path(tmp)
+        
+        # Mock BASE_DIR to be our temporary directory
+        with mock.patch('alcove.utils.BASE_DIR', tmp_path):
+            # Create .gitignore with existing entry
+            gitignore_path = tmp_path / ".gitignore"
+            gitignore_path.write_text("existing/entry\n")
+            
+            # Create a file that matches the existing entry
+            entry_path = tmp_path / "existing" / "entry"
+            entry_path.parent.mkdir(parents=True)
+            entry_path.touch()
+            
+            # Try to add the same entry
+            add_to_gitignore(entry_path)
+            
+            # Check no duplicate was added
+            content = gitignore_path.read_text().strip().split('\n')
+            assert len(content) == 1
+            assert "existing/entry" in content
+
+
+def test_ensure_data_files_in_gitignore():
+    """Test that ensure_data_files_in_gitignore works correctly"""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        
+        # Test with non-existent .gitignore
+        ensure_data_files_in_gitignore()
+        
+        # Check the file was created with the right entry
+        gitignore_path = Path(tmp) / ".gitignore"
+        assert gitignore_path.exists()
+        content = gitignore_path.read_text().strip()
+        assert content == ".data-files"
+        
+        # Test idempotence - calling again shouldn't add duplicate
+        ensure_data_files_in_gitignore()
+        content = gitignore_path.read_text().strip()
+        assert content == ".data-files"
+
+
+def test_add_to_data_files():
+    """Test that add_to_data_files works correctly"""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        tmp_path = Path(tmp)
+        
+        # Mock BASE_DIR to be our temporary directory
+        with mock.patch('alcove.utils.BASE_DIR', tmp_path):
+            # Create a test file
+            data_dir = tmp_path / "data" / "test"
+            data_dir.mkdir(parents=True)
+            test_file = data_dir / "path"
+            test_file.touch()
+            
+            # Test with non-existent .data-files
+            add_to_data_files(test_file)
+            
+            # Check both files were created with the right entries
+            gitignore_path = tmp_path / ".gitignore"
+            data_files_path = tmp_path / ".data-files"
+            
+            assert gitignore_path.exists()
+            assert data_files_path.exists()
+            
+            gitignore_content = gitignore_path.read_text().strip()
+            data_files_content = data_files_path.read_text().strip()
+            
+            assert gitignore_content == ".data-files"
+            assert data_files_content == "data/test/path"
+            
+            # Add another entry
+            test_file2 = data_dir / "another" / "path"
+            test_file2.parent.mkdir(parents=True)
+            test_file2.touch()
+            add_to_data_files(test_file2)
+            
+            # Check the new entry was added to .data-files only
+            data_files_content = data_files_path.read_text().strip().split('\n')
+            assert "data/test/path" in data_files_content
+            assert "data/test/another/path" in data_files_content
+            
+            # Check .gitignore remains unchanged
+            gitignore_content = gitignore_path.read_text().strip()
+            assert gitignore_content == ".data-files"
+        
+        
+def test_audit_gitignore_setup():
+    """Test that audit_gitignore_setup works correctly"""
+    with tempfile.TemporaryDirectory() as tmp:
+        os.chdir(tmp)
+        
+        # Create a .gitignore with data file patterns
+        gitignore_path = Path(tmp) / ".gitignore"
+        gitignore_path.write_text("data/snapshots/test/path\ndata/snapshots/another/path\nother/file\n")
+        
+        # Run audit with fix=True
+        audit_gitignore_setup(fix=True)
+        
+        # Check that .data-files was created and contains the data patterns
+        data_files_path = Path(tmp) / ".data-files"
+        assert data_files_path.exists()
+        
+        data_files_content = data_files_path.read_text().strip().split("\n")
+        assert "data/snapshots/test/path" in data_files_content
+        assert "data/snapshots/another/path" in data_files_content
+        
+        # Check that .gitignore now only contains non-data patterns and .data-files
+        gitignore_content = gitignore_path.read_text().strip().split("\n")
+        assert ".data-files" in gitignore_content
+        assert "other/file" in gitignore_content
+        assert "data/snapshots/test/path" not in gitignore_content
+        assert "data/snapshots/another/path" not in gitignore_content


### PR DESCRIPTION
## Summary
- Add `.data-files` file to store alcove data ignore patterns
- Ensure `.gitignore` includes a reference to `.data-files`
- Move existing patterns from `.gitignore` to `.data-files` on `audit --fix`
- Prevents `.gitignore` from changing frequently with data file updates

## Test plan
- Added comprehensive test suite in `tests/test_gitignore.py`
- Updated existing tests in `tests/test_alcove.py` to expect patterns in `.data-files`
- All tests pass with `make test`

🤖 Generated with [Claude Code](https://claude.ai/code)