### PR TITLE
Add date partitioned snapshots and tables via wildcards

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/configure-pages@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install zensical
+      - run: zensical build --clean
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help unittest format lint typecheck test act build publish
+.PHONY: help unittest format lint typecheck test act build publish docs docs-build
 
 # Default target
 help:
@@ -11,6 +11,8 @@ help:
 	@echo "  make act            - Run GitHub Actions locally with act"
 	@echo "  make build          - Build package for distribution"
 	@echo "  make publish        - Publish package to PyPI"
+	@echo "  make docs           - Serve docs locally"
+	@echo "  make docs-build     - Build docs with strict checking"
 
 # Reformat using ruff
 format:
@@ -55,3 +57,11 @@ build:
 publish: build
 	@echo "==> Publishing to PyPI"
 	@uv run twine upload dist/*
+
+docs:
+	@echo "==> Serving docs locally"
+	@uv run zensical serve
+
+docs-build:
+	@echo "==> Building docs"
+	@uv run zensical build --clean

--- a/README.md
+++ b/README.md
@@ -277,6 +277,11 @@ Please report any issues at: <https://github.com/larsyencken/alcove/issues>
 
 ## Changelog
 
+- `dev`
+  - Added wildcard `*` support in step URIs for date-partitioned tables (e.g. `table://foo/*` expands per snapshot version)
+  - `AlcoveDB` now registers union views across all partitions of a wildcard group
+  - Fixed DAG mutation bug in `plan_and_run` (steps dict is now copied before modification)
+
 - `0.2.2`
   - Fixed `snapshot --force` failing with `FileExistsError` when overwriting directory snapshots
   - Added programmatic API: `alcove.connect()` returns an `AlcoveDB` that queries tables as Polars DataFrames

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 _A personal ETL and data lake._
 
-Status: in alpha, changing often
-
 ## Overview
 
 Alcove is an opinionated small-scale ETL framework for managing data files and directories in a content-addressable way.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,43 @@
+# Changelog
+
+- `dev`
+    - Added wildcard `*` support in step URIs for date-partitioned tables (e.g. `table://foo/*` expands per snapshot version)
+    - `AlcoveDB` now registers union views across all partitions of a wildcard group
+    - Fixed DAG mutation bug in `plan_and_run` (steps dict is now copied before modification)
+
+- `0.2.2`
+    - Fixed `snapshot --force` failing with `FileExistsError` when overwriting directory snapshots
+    - Added programmatic API: `alcove.connect()` returns an `AlcoveDB` that queries tables as Polars DataFrames
+    - Enforced `dim_` columns as composite primary key when new tables are generated
+
+- `0.2.1` (2025-04-28)
+    - Fixed gitignore handling by using `data/.gitignore` instead of `.data-files`
+    - Always include `tables/` in `data/.gitignore`
+    - `alcove audit --fix` now migrates patterns from `.gitignore` and `.data-files` to `data/.gitignore`
+
+- `0.2.0` (2025-04-28)
+    - Added `.data-files` file for managing alcove data ignores (#61)
+    - `alcove init` now creates empty `.data-files` and ensures it's in `.gitignore`
+    - `alcove audit --fix` can move patterns from `.gitignore` to `.data-files`
+    - Prevents `.gitignore` from changing frequently with data file updates
+
+- `0.1.2` (2025-04-25)
+    - Fixed B2 compatibility with recent boto3 versions by disabling checksum validation (#60)
+    - Simplified testing approach by always requiring Docker with MinIO
+    - Added PyPI package configuration and installation instructions
+    - Improved documentation with quick start guide and command reference
+
+- `0.1.1` (2025-04-25)
+    - Renamed project from "shelf" to "alcove"
+    - Added automated Docker container management for testing with MinIO
+    - Enhanced Docker context support for different environments (Docker Desktop, Colima, OrbStack)
+    - Improved S3-compatible storage testing reliability
+    - Fixed test fixtures to use consistent credentials
+
+- `0.1.0` (Initial release)
+    - Initialise a repo with `shelf.yaml`
+    - `shelf snapshot` and `shelf run` with file and directory support
+    - Only fetch things that are out of date
+    - `shelf list` to see what datasets are available
+    - `shelf audit` to ensure your alcove is coherent and correct
+    - `shelf db` to enter an interactive DuckDB shell with all your data

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,91 @@
+# Commands
+
+## Command Reference
+
+Alcove provides the following commands:
+
+| Command | Description |
+|---------|-------------|
+| `alcove init` | Initialize a new alcove workspace |
+| `alcove snapshot <path> <dataset>` | Add a file or directory to your alcove |
+| `alcove run` | Build all tables and fetch outdated data |
+| `alcove list` | List all datasets in alphabetical order |
+| `alcove audit` | Validate the alcove metadata |
+| `alcove new-table <path> [deps...]` | Create a new derived table |
+| `alcove db [query]` | Open a DuckDB shell or execute a query |
+| `alcove export-duckdb <file>` | Export tables to a DuckDB file |
+
+## Creating a new table
+
+To create a new table, use the `new-table` command:
+
+```bash
+alcove new-table <table-path> [dep1 [dep2 [...]]]
+```
+
+This creates a placeholder executable script that generates an example data file based on the file extension (.parquet or .sql).
+
+### Creating a Parquet table
+
+```bash
+alcove new-table path/to/your/table
+```
+
+This creates a placeholder Python script that generates an example Parquet file:
+
+```python
+#!/usr/bin/env python3
+import sys
+import polars as pl
+
+data = {
+    "a": [1, 1, 3],
+    "b": [2, 3, 5],
+    "c": [3, 4, 6]
+}
+
+df = pl.DataFrame(data)
+
+output_file = sys.argv[-1]
+df.write_parquet(output_file)
+```
+
+### Creating a SQL table
+
+```bash
+alcove new-table path/to/your/table.sql
+```
+
+This creates a placeholder SQL script:
+
+```sql
+-- SQL script to create a table
+CREATE TABLE example_table AS
+SELECT
+    1 AS a,
+    2 AS b,
+    3 AS c
+```
+
+### Opening in your editor
+
+The command also supports the `--edit` option to open the metadata file in your editor:
+
+```bash
+alcove new-table path/to/your/table --edit
+```
+
+## Executing SQL step definitions
+
+If a `.sql` step definition is detected, it will be executed using DuckDB with an in-memory database. The SQL file can use `{variable}` to interpolate template variables. The following template variables are available:
+
+- `{output_file}`: The path to the output file.
+- `{dependency}`: The path of each dependency, simplified to a semantic name.
+
+## Building your alcove
+
+Run the `run` command to fetch any data that's out of date and build any derived tables:
+
+```bash
+alcove run
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,35 @@
+# Development
+
+## Testing with MinIO
+
+For testing with S3-compatible storage, this project uses automatically managed containers:
+
+```bash
+# Run tests with Docker-based MinIO
+make test
+```
+
+All tests require Docker with MinIO container to be available.
+
+## Docker Context Support
+
+The testing framework automatically detects your current Docker context and uses it for container operations. This ensures tests work properly with:
+
+- Docker Desktop
+- Colima
+- OrbStack
+- Remote Docker contexts
+
+## MinIO Configuration
+
+With Docker, these credentials are automatically used:
+
+| Setting | Value |
+|---------|-------|
+| Access Key | `minioadmin` |
+| Secret Key | `minioadmin` |
+| Bucket | `test-bucket` |
+| Endpoint | `http://localhost:9000` |
+
+Containers are automatically managed and kept running between test runs for performance.
+MinIO's health is verified before tests run to ensure proper S3 compatibility.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,103 @@
+# Getting Started
+
+## Install the package
+
+You can install the `alcove` package from PyPI using pip, uv, or any other Python package manager:
+
+```bash
+# Using pip
+pip install alcove
+
+# Using uv (recommended)
+uv add alcove
+
+# For development
+uv add --dev alcove
+```
+
+You can also install directly from GitHub for the latest development version:
+
+```bash
+pip install git+https://github.com/larsyencken/alcove
+```
+
+## Starting a new project
+
+To start a new project with alcove:
+
+```bash
+# Create and navigate to your project directory
+mkdir my-data-project
+cd my-data-project
+
+# Set up your Python environment (optional, but recommended)
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+
+# Install alcove
+pip install alcove
+
+# Or with uv
+uv add alcove
+
+# Initialize the alcove
+alcove init
+```
+
+## Adding to an existing project
+
+To add alcove to an existing project:
+
+```bash
+# Navigate to your project directory
+cd your-project
+
+# Install alcove
+uv add alcove   # Or pip install alcove
+
+# Initialize alcove in a subdirectory (optional)
+mkdir data
+cd data
+alcove init
+```
+
+## Initialise an alcove
+
+From the folder where you want to store your data and metadata, run:
+
+```bash
+alcove init
+```
+
+This will create a `alcove.yaml` file, which will serve as the catalogue of all the data in your alcove.
+
+## Configure object storage
+
+You will need to configure your S3-compatible storage credentials in a `.env` file, in the same directory as your `alcove.yaml` file. Define:
+
+```
+S3_ACCESS_KEY=your_application_key_id
+S3_SECRET_KEY=your_application_key
+S3_BUCKET_NAME=your_bucket_name
+S3_ENDPOINT_URL=your_endpoint_url
+```
+
+Now your alcove is ready to use.
+
+## Adding a file or folder
+
+From within your alcove folder, use the `snapshot` command to add a file or folder to your alcove:
+
+```bash
+alcove snapshot path/to/your/file_or_folder dataset_name
+```
+
+For example:
+
+```bash
+alcove snapshot ~/Downloads/countries.csv countries/latest
+```
+
+This will upload the file to your S3-compatible storage, and create a metadata file at `data/<dataset_name>.meta.yaml` directory for you to complete.
+
+The metadata format has some minimum fields, but is meant for you to extend as needed for your own purposes. Best practice would be to retain the provenance and licence information of any data you add to your alcove, especially if it originates from a third party.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+# Alcove
+
+[![CI](https://github.com/larsyencken/alcove/actions/workflows/ci.yml/badge.svg)](https://github.com/larsyencken/alcove/actions/workflows/ci.yml)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
+
+_A personal ETL and data lake._
+
+## Overview
+
+Alcove is an opinionated small-scale ETL framework for managing data files and directories in a content-addressable way.
+
+## Core principles
+
+- **A reusable framework.** Alcove provides a structured way of managing data files, scripts and their interdependencies that can be used across multiple projects.
+- **First class metadata.** Every data file has an accompanying metadata sidecar that can be used to store provenance, licensing and other information.
+- **Content addressed.** An `alcove` DAG is a Merkle tree of checksums that includes data, metadata and scripts, used to lazily rebuild only what is out of date.
+- **Data versioning.** Every step in the DAG has a URI that includes a version, which can be an ISO date or `latest`, to encourage a reproducible workflow that still allows for change.
+- **SQL support.** Alcove is a Python framework, but allows you to write steps in SQL which will be executed by DuckDB.
+- **Parquet interchange.** All derived tables are generated as Parquet, which makes reuse easier.
+
+## Quick Start
+
+```bash
+# Install alcove
+pip install alcove  # or: uv add alcove
+
+# Initialize a new alcove
+mkdir my-data-project && cd my-data-project
+alcove init
+
+# Add a data file to your alcove
+alcove snapshot ~/Downloads/countries.csv countries/latest
+
+# Create a derived table
+alcove new-table derived/population.sql countries/latest
+
+# Build all tables
+alcove run
+
+# Explore your data with DuckDB
+alcove db
+```
+
+## Bugs
+
+Please report any issues at: [github.com/larsyencken/alcove/issues](https://github.com/larsyencken/alcove/issues)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1,0 +1,103 @@
+# Python API
+
+Alcove provides a programmatic Python API through `AlcoveDB`, which lets you query your tables as Polars DataFrames using DuckDB.
+
+## Connecting
+
+Use `alcove.connect()` from within your alcove directory (where `alcove.yaml` lives):
+
+```python
+import alcove
+
+db = alcove.connect()
+print(db.tables)  # list all available tables
+```
+
+## Querying tables
+
+### By table name
+
+Pass a table name to `sql()` to get all rows:
+
+```python
+df = db.sql("countries")
+```
+
+### With SQL
+
+Pass a full SQL query:
+
+```python
+df = db.sql("SELECT name, population FROM countries WHERE population > 1000000")
+```
+
+### query() alias
+
+`query()` is an alias for `sql()`:
+
+```python
+df = db.query("SELECT * FROM countries")
+```
+
+## Table naming
+
+By default (`names="both"`), tables are registered under both their full path name and a short alias. You can control this with the `names` parameter:
+
+```python
+# Both full and short names (default)
+db = alcove.connect(names="both")
+
+# Only full path names (e.g. "derived_population_latest")
+db = alcove.connect(names="full")
+
+# Only short aliases (e.g. "population")
+db = alcove.connect(names="short")
+```
+
+## Context manager
+
+`AlcoveDB` supports use as a context manager:
+
+```python
+import alcove
+
+with alcove.connect() as db:
+    df = db.sql("SELECT * FROM countries")
+    print(df)
+# connection is closed automatically
+```
+
+## Direct DuckDB access
+
+For advanced use, access the underlying DuckDB connection:
+
+```python
+db = alcove.connect()
+result = db.conn.execute("SHOW TABLES").fetchall()
+```
+
+## API Reference
+
+### `alcove.connect(alcove=None, names="both")`
+
+Open a queryable connection to all Alcove tables.
+
+- **alcove** — Optional `Alcove` instance. If `None`, creates one from the current directory.
+- **names** — Table naming strategy: `"short"`, `"full"`, or `"both"` (default).
+- **Returns** — `AlcoveDB` instance.
+
+### `AlcoveDB.sql(query)` / `AlcoveDB.query(query)`
+
+Execute a SQL query and return a Polars DataFrame. If `query` contains no spaces, it is treated as a table name and expanded to `SELECT * FROM "query"`.
+
+### `AlcoveDB.tables`
+
+List of all registered table names.
+
+### `AlcoveDB.conn`
+
+The underlying `duckdb.DuckDBPyConnection`.
+
+### `AlcoveDB.close()`
+
+Close the database connection.

--- a/docs/wildcards.md
+++ b/docs/wildcards.md
@@ -1,0 +1,49 @@
+# Wildcards
+
+Alcove supports wildcard `*` steps for date-partitioned tables, allowing you to write a single script that gets reused across many versions of a dataset.
+
+## How it works
+
+A wildcard step URI like `table://foo/*` tells Alcove to expand the step into one concrete step per discovered version. Versions are discovered by scanning the DAG for concrete steps that share the same base path.
+
+For example, if you have snapshots `snapshot://raw/2025-01`, `snapshot://raw/2025-02`, and `snapshot://raw/2025-03`, a wildcard table `table://clean/*` that depends on `snapshot://raw/*` will automatically expand into three concrete steps: `table://clean/2025-01`, `table://clean/2025-02`, and `table://clean/2025-03`.
+
+## Configuration
+
+Define wildcard steps in your `alcove.yaml` using `*` as the version:
+
+```yaml
+steps:
+  # Concrete snapshots with specific versions
+  - uri: snapshot://raw/2025-01
+  - uri: snapshot://raw/2025-02
+  - uri: snapshot://raw/2025-03
+
+  # Wildcard table: one script runs per version
+  - uri: table://clean/*
+    deps:
+      - snapshot://raw/*
+
+  # Another wildcard table that chains off the first
+  - uri: table://summary/*
+    deps:
+      - table://clean/*
+```
+
+The build script for `table://clean/*` is written once and reused for each version. During `alcove run`, the wildcard expands and the script executes once per version, receiving the correct versioned dependency paths.
+
+## Chained wildcards
+
+Wildcard steps can depend on other wildcard steps. In the example above, `table://summary/*` depends on `table://clean/*`. Alcove processes wildcards in topological order, so `clean/*` is expanded first, and `summary/*` inherits the same set of versions.
+
+## Union views in AlcoveDB
+
+When you query wildcard tables through `AlcoveDB`, Alcove automatically creates a union view that combines all partitions. For a wildcard group `table://clean/*`, the view reads all matching Parquet files via `data/tables/clean/*.parquet`, giving you a single table with all versions combined.
+
+```python
+import alcove
+
+db = alcove.connect()
+# Query across all partitions at once
+df = db.sql("SELECT * FROM clean")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+site_name: Alcove
+site_description: An opinionated small-scale ETL framework for managing data files and directories in a content-addressable way.
+site_url: https://larsyencken.github.io/alcove/
+repo_url: https://github.com/larsyencken/alcove
+repo_name: larsyencken/alcove
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - navigation.instant
+    - navigation.sections
+
+nav:
+  - Overview: index.md
+  - Getting Started: getting-started.md
+  - Commands: commands.md
+  - Wildcards: wildcards.md
+  - Python API: python-api.md
+  - Development: development.md
+  - Changelog: changelog.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.sdist]
 exclude = [".claude/"]
 
-[tool.rye]
-managed = true
-dev-dependencies = ["pytest>=8.3.1", "minio>=7.2.7"]
-
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "minio>=7.2.10",
     "pyright>=1.1.387",
     "pytest>=8.3.3",
@@ -55,4 +51,5 @@ dev-dependencies = [
     "docker>=7.0.0",
     "twine>=6.1.0",
     "hatchling>=1.27.0",
+    "zensical>=0.0.23",
 ]

--- a/src/alcove/__init__.py
+++ b/src/alcove/__init__.py
@@ -294,7 +294,7 @@ def plan_and_run(
     for step, dependencies in dag.items():
         dag[step] = resolve_latest(dependencies, alcove)
 
-    dag, wildcard_groups = expand_wildcards(dag)
+    dag, _ = expand_wildcards(dag)
 
     if regex:
         dag = steps.prune_with_regex(dag, regex)
@@ -306,7 +306,7 @@ def plan_and_run(
         print("Already up to date!")
         return
 
-    steps.execute_dag(dag, dry_run=dry_run, wildcard_groups=wildcard_groups)
+    steps.execute_dag(dag, dry_run=dry_run)
 
 
 def resolve_latest(dependencies: list[StepURI], alcove: Alcove) -> list[StepURI]:
@@ -330,7 +330,7 @@ def export_duckdb(alcove: Alcove, db_file: str, short: bool = False) -> None:
 
     tables = _get_tables(alcove)
     for table in tables:
-        if table.endswith("/*"):
+        if StepURI("table", table).is_wildcard:
             continue
         table_name = table.replace("/", "_").replace("-", "").rsplit(".", 1)[0]
         table_path = (Path("data/tables") / table).with_suffix(".parquet")

--- a/src/alcove/__init__.py
+++ b/src/alcove/__init__.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 
 from alcove import steps
 from alcove.core import Alcove
+from alcove.wildcards import expand_wildcards
 from alcove.db import (
     AlcoveDB as AlcoveDB,
     connect as connect,
@@ -265,7 +266,7 @@ def list_steps_cmd(
 def list_steps(
     alcove: Alcove, regex: str | None = None, paths: bool = False
 ) -> list[Path] | list[StepURI]:
-    steps = sorted(alcove.steps)
+    steps = sorted(s for s in alcove.steps if not s.is_wildcard)
 
     if regex:
         steps = [s for s in steps if re.search(regex, str(s))]
@@ -288,10 +289,12 @@ def plan_and_run(
     # XXX in the future, we could create a Plan object that explains why each step has
     #     been selected to be run, even down to the level of which checksums are out of
     #     date or which files are missing
-    dag = alcove.steps
+    dag = dict(alcove.steps)
 
     for step, dependencies in dag.items():
         dag[step] = resolve_latest(dependencies, alcove)
+
+    dag, wildcard_groups = expand_wildcards(dag)
 
     if regex:
         dag = steps.prune_with_regex(dag, regex)
@@ -303,7 +306,7 @@ def plan_and_run(
         print("Already up to date!")
         return
 
-    steps.execute_dag(dag, dry_run=dry_run)
+    steps.execute_dag(dag, dry_run=dry_run, wildcard_groups=wildcard_groups)
 
 
 def resolve_latest(dependencies: list[StepURI], alcove: Alcove) -> list[StepURI]:
@@ -327,6 +330,8 @@ def export_duckdb(alcove: Alcove, db_file: str, short: bool = False) -> None:
 
     tables = _get_tables(alcove)
     for table in tables:
+        if table.endswith("/*"):
+            continue
         table_name = table.replace("/", "_").replace("-", "").rsplit(".", 1)[0]
         table_path = (Path("data/tables") / table).with_suffix(".parquet")
 
@@ -368,6 +373,8 @@ def audit_alcove(alcove: Alcove, fix: bool = False) -> None:
 
     # Check all steps
     for step in alcove.steps:
+        if step.is_wildcard:
+            continue
         audit_step(step, fix)
         console.print(f"[blue]{'OK':>5}[/blue]   {step}")
 

--- a/src/alcove/core.py
+++ b/src/alcove/core.py
@@ -74,6 +74,8 @@ class Alcove:
         versions = [
             s
             for s in self.steps
-            if s.scheme == step.scheme and s.path.startswith(prefix)
+            if s.scheme == step.scheme
+            and s.path.startswith(prefix)
+            and not s.is_wildcard
         ]
         return max(versions)

--- a/src/alcove/db.py
+++ b/src/alcove/db.py
@@ -21,6 +21,7 @@ class AlcoveDB:
             alcove = Alcove()
 
         tables = _get_tables(alcove)
+        wildcard_tables = _get_wildcard_tables(alcove)
 
         self._conn = duckdb.connect(":memory:")
         for path in tables:
@@ -28,6 +29,14 @@ class AlcoveDB:
             table_path = (Path("data/tables") / path).with_suffix(".parquet")
             self._conn.execute(
                 f"CREATE VIEW \"{table_name}\" AS SELECT * FROM read_parquet('{table_path}')"
+            )
+
+        # Create union views for wildcard groups
+        for base_path in wildcard_tables:
+            union_name = _path_to_snake(base_path)
+            glob_path = Path("data/tables") / base_path / "*.parquet"
+            self._conn.execute(
+                f"CREATE VIEW \"{union_name}\" AS SELECT * FROM read_parquet('{glob_path}')"
             )
 
         if names == "both":
@@ -88,10 +97,19 @@ def _path_to_snake(path: str) -> str:
 def _get_tables(alcove: Alcove) -> list[str]:
     tables = []
     for step in alcove.steps:
-        if step.scheme == "table":
+        if step.scheme == "table" and not step.is_wildcard:
             tables.append(step.path)
 
     return tables
+
+
+def _get_wildcard_tables(alcove: Alcove) -> list[str]:
+    """Return base_paths for table://*  entries."""
+    bases = []
+    for step in alcove.steps:
+        if step.scheme == "table" and step.is_wildcard:
+            bases.append(step.base_path)
+    return bases
 
 
 def _table_aliases(tables: list[str]) -> list[tuple[str, str]]:

--- a/src/alcove/schemas/alcove-v1.schema.json
+++ b/src/alcove/schemas/alcove-v1.schema.json
@@ -25,7 +25,7 @@
           "minItems": 0,
           "items": {
             "type": "string",
-            "$oneOf": [
+            "oneOf": [
               {
                 "pattern": "^snapshot://[a-z0-9-/*]+$"
               },

--- a/src/alcove/schemas/alcove-v1.schema.json
+++ b/src/alcove/schemas/alcove-v1.schema.json
@@ -27,10 +27,10 @@
             "type": "string",
             "$oneOf": [
               {
-                "pattern": "^snapshot://[a-z0-9-/]+$"
+                "pattern": "^snapshot://[a-z0-9-/*]+$"
               },
               {
-                "pattern": "^table://[a-z0-9-/]+.(jsonl|csv|feather)$"
+                "pattern": "^table://[a-z0-9-/*]+$"
               }
             ]
           }

--- a/src/alcove/schemas/alcove-v1.schema.json
+++ b/src/alcove/schemas/alcove-v1.schema.json
@@ -27,10 +27,10 @@
             "type": "string",
             "oneOf": [
               {
-                "pattern": "^snapshot://[a-z0-9-/*]+$"
+                "pattern": "^snapshot://[a-z0-9_/*]+$"
               },
               {
-                "pattern": "^table://[a-z0-9-/*]+$"
+                "pattern": "^table://[a-z0-9_/*]+$"
               }
             ]
           }

--- a/src/alcove/steps.py
+++ b/src/alcove/steps.py
@@ -64,31 +64,23 @@ def is_completed(step: StepURI, deps: list[StepURI]) -> bool:
     raise ValueError(f"Unknown scheme {step.scheme}")
 
 
-def execute_dag(
-    dag: Dag,
-    dry_run: bool = False,
-    wildcard_groups: dict[str, list[str]] | None = None,
-) -> None:
+def execute_dag(dag: Dag, dry_run: bool = False) -> None:
     "Execute the DAG."
     to_execute = in_topological_order(dag)
     print(f"Executing {len(to_execute)} steps")
     for step in to_execute:
         print(step)
         if not dry_run:
-            execute_step(step, dag[step], wildcard_groups=wildcard_groups)
+            execute_step(step, dag[step])
 
 
-def execute_step(
-    step: StepURI,
-    dependencies: List[StepURI],
-    wildcard_groups: dict[str, list[str]] | None = None,
-) -> None:
+def execute_step(step: StepURI, dependencies: List[StepURI]) -> None:
     "Execute a single step."
     if step.scheme == "snapshot":
         return snapshots.Snapshot.load(step.path).fetch()
 
     elif step.scheme == "table":
-        return tables.build_table(step, dependencies, wildcard_groups=wildcard_groups)
+        return tables.build_table(step, dependencies)
 
     else:
         raise ValueError(f"Unknown scheme {step.scheme}")

--- a/src/alcove/steps.py
+++ b/src/alcove/steps.py
@@ -64,23 +64,31 @@ def is_completed(step: StepURI, deps: list[StepURI]) -> bool:
     raise ValueError(f"Unknown scheme {step.scheme}")
 
 
-def execute_dag(dag: Dag, dry_run: bool = False) -> None:
+def execute_dag(
+    dag: Dag,
+    dry_run: bool = False,
+    wildcard_groups: dict[str, list[str]] | None = None,
+) -> None:
     "Execute the DAG."
     to_execute = in_topological_order(dag)
     print(f"Executing {len(to_execute)} steps")
     for step in to_execute:
         print(step)
         if not dry_run:
-            execute_step(step, dag[step])
+            execute_step(step, dag[step], wildcard_groups=wildcard_groups)
 
 
-def execute_step(step: StepURI, dependencies: List[StepURI]) -> None:
+def execute_step(
+    step: StepURI,
+    dependencies: List[StepURI],
+    wildcard_groups: dict[str, list[str]] | None = None,
+) -> None:
     "Execute a single step."
     if step.scheme == "snapshot":
         return snapshots.Snapshot.load(step.path).fetch()
 
     elif step.scheme == "table":
-        return tables.build_table(step, dependencies)
+        return tables.build_table(step, dependencies, wildcard_groups=wildcard_groups)
 
     else:
         raise ValueError(f"Unknown scheme {step.scheme}")

--- a/src/alcove/tables.py
+++ b/src/alcove/tables.py
@@ -13,7 +13,11 @@ from alcove.exceptions import ValidationError
 from alcove.paths import TABLE_DIR
 from alcove.schemas import TABLE_SCHEMA
 from alcove.snapshots import Snapshot
-from alcove.table_metadata import _get_executable, _metadata_path, process_table_metadata
+from alcove.table_metadata import (
+    _get_executable,
+    _metadata_path,
+    process_table_metadata,
+)
 from alcove.types import Manifest, StepURI
 from alcove.utils import checksum_file, load_yaml, print_op, save_yaml
 

--- a/src/alcove/tables.py
+++ b/src/alcove/tables.py
@@ -52,16 +52,12 @@ def is_completed(uri: StepURI, deps: list[StepURI]) -> bool:
     return True
 
 
-def build_table(
-    uri: StepURI,
-    dependencies: list[StepURI],
-    wildcard_groups: dict[str, list[str]] | None = None,
-) -> None:
+def build_table(uri: StepURI, dependencies: list[StepURI]) -> None:
     """Build a table and handle its metadata."""
     assert uri.scheme == "table"
 
     dest_path = _prepare_output_path(uri)
-    runtime_info = _execute_table_build(uri, dependencies, dest_path, wildcard_groups)
+    runtime_info = _execute_table_build(uri, dependencies, dest_path)
     _handle_metadata(uri, dependencies, dest_path, runtime_info)
 
 
@@ -78,10 +74,9 @@ def _execute_table_build(
     uri: StepURI,
     dependencies: list[StepURI],
     dest_path: Path,
-    wildcard_groups: dict[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     """Execute the table build and return runtime information."""
-    command = _generate_build_command(uri, dependencies, wildcard_groups)
+    command = _generate_build_command(uri, dependencies)
     start_time = datetime.now()
     runtime_info: dict[str, Any] = {
         "start_time": start_time.isoformat(),
@@ -128,19 +123,20 @@ def _handle_metadata(
 
 
 def _generate_build_command(
-    uri: StepURI,
-    dependencies: list[StepURI],
-    wildcard_groups: dict[str, list[str]] | None = None,
+    uri: StepURI, dependencies: list[StepURI]
 ) -> list[Path]:
     executable = _get_executable(uri)
 
     cmd = [executable]
 
-    # Check if any deps should be collapsed to a glob path
+    # When multiple deps share the same scheme + base_path (1:n wildcard
+    # expansion), collapse them into a single glob path instead of passing
+    # each version individually.
+    group_counts = Counter(f"{d.scheme}://{d.base_path}" for d in dependencies)
     added_globs: set[str] = set()
     for dep in dependencies:
         group_key = f"{dep.scheme}://{dep.base_path}"
-        if wildcard_groups and group_key in wildcard_groups:
+        if group_counts[group_key] > 1:
             if group_key not in added_globs:
                 cmd.append(_dependency_glob_path(dep))
                 added_globs.add(group_key)

--- a/src/alcove/tables.py
+++ b/src/alcove/tables.py
@@ -10,7 +10,7 @@ import jsonschema
 import polars as pl
 
 from alcove.exceptions import ValidationError
-from alcove.paths import TABLE_DIR
+from alcove.paths import SNAPSHOT_DIR, TABLE_DIR
 from alcove.schemas import TABLE_SCHEMA
 from alcove.snapshots import Snapshot
 from alcove.table_metadata import (
@@ -52,12 +52,16 @@ def is_completed(uri: StepURI, deps: list[StepURI]) -> bool:
     return True
 
 
-def build_table(uri: StepURI, dependencies: list[StepURI]) -> None:
+def build_table(
+    uri: StepURI,
+    dependencies: list[StepURI],
+    wildcard_groups: dict[str, list[str]] | None = None,
+) -> None:
     """Build a table and handle its metadata."""
     assert uri.scheme == "table"
 
     dest_path = _prepare_output_path(uri)
-    runtime_info = _execute_table_build(uri, dependencies, dest_path)
+    runtime_info = _execute_table_build(uri, dependencies, dest_path, wildcard_groups)
     _handle_metadata(uri, dependencies, dest_path, runtime_info)
 
 
@@ -71,10 +75,13 @@ def _prepare_output_path(uri: StepURI) -> Path:
 
 
 def _execute_table_build(
-    uri: StepURI, dependencies: list[StepURI], dest_path: Path
+    uri: StepURI,
+    dependencies: list[StepURI],
+    dest_path: Path,
+    wildcard_groups: dict[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     """Execute the table build and return runtime information."""
-    command = _generate_build_command(uri, dependencies)
+    command = _generate_build_command(uri, dependencies, wildcard_groups)
     start_time = datetime.now()
     runtime_info: dict[str, Any] = {
         "start_time": start_time.isoformat(),
@@ -120,12 +127,25 @@ def _handle_metadata(
         raise
 
 
-def _generate_build_command(uri: StepURI, dependencies: list[StepURI]) -> list[Path]:
+def _generate_build_command(
+    uri: StepURI,
+    dependencies: list[StepURI],
+    wildcard_groups: dict[str, list[str]] | None = None,
+) -> list[Path]:
     executable = _get_executable(uri)
 
     cmd = [executable]
+
+    # Check if any deps should be collapsed to a glob path
+    added_globs: set[str] = set()
     for dep in dependencies:
-        cmd.append(_dependency_path(dep))
+        group_key = f"{dep.scheme}://{dep.base_path}"
+        if wildcard_groups and group_key in wildcard_groups:
+            if group_key not in added_globs:
+                cmd.append(_dependency_glob_path(dep))
+                added_globs.add(group_key)
+        else:
+            cmd.append(_dependency_path(dep))
 
     dest_path = TABLE_DIR / f"{uri.path}.parquet"
     cmd.append(dest_path)
@@ -139,6 +159,17 @@ def _dependency_path(uri: StepURI) -> Path:
 
     elif uri.scheme == "table":
         return TABLE_DIR / f"{uri.path}.parquet"
+    else:
+        raise ValueError(f"Unknown scheme {uri.scheme}")
+
+
+def _dependency_glob_path(uri: StepURI) -> Path:
+    """Return a glob path for all versions under a base_path, e.g. data/tables/foo/*.parquet."""
+    if uri.scheme == "snapshot":
+        return SNAPSHOT_DIR / uri.base_path / "*"
+
+    elif uri.scheme == "table":
+        return TABLE_DIR / uri.base_path / "*.parquet"
     else:
         raise ValueError(f"Unknown scheme {uri.scheme}")
 

--- a/src/alcove/types.py
+++ b/src/alcove/types.py
@@ -24,6 +24,24 @@ class StepURI:
         return f"{self.scheme}://{self.path}"
 
     @property
+    def is_wildcard(self) -> bool:
+        return self.path.endswith("/*")
+
+    @property
+    def base_path(self) -> str:
+        """Path prefix before the last segment, e.g. 'foo/bar/*' -> 'foo/bar'."""
+        return self.path.rsplit("/", 1)[0]
+
+    @property
+    def version(self) -> str:
+        """Last path segment, e.g. 'foo/2025-02-17' -> '2025-02-17'."""
+        return self.path.rsplit("/", 1)[-1]
+
+    def with_version(self, v: str) -> "StepURI":
+        """Replace last segment with a new version."""
+        return StepURI(self.scheme, f"{self.base_path}/{v}")
+
+    @property
     def full_path(self):
         if self.scheme == "snapshot":
             return paths.SNAPSHOT_DIR / self.path

--- a/src/alcove/utils.py
+++ b/src/alcove/utils.py
@@ -56,7 +56,7 @@ def print_op(type_: str, message: Any) -> None:
 def add_entry_to_file(file_path: Path, entry: str) -> None:
     """
     Add an entry to a file if it doesn't already exist.
-    
+
     Args:
         file_path: The path to the file to add the entry to
         entry: The string to add to the file
@@ -84,12 +84,12 @@ def ensure_data_gitignore() -> None:
     """
     data_dir = Path("data")
     data_gitignore = data_dir / ".gitignore"
-    
+
     # Create data directory if it doesn't exist
     if not data_dir.exists():
         data_dir.mkdir(parents=True, exist_ok=True)
         print_op("CREATE", "data/")
-    
+
     # Create data/.gitignore if it doesn't exist with the tables/ entry
     if not data_gitignore.exists():
         data_gitignore.write_text("tables/\n")
@@ -98,7 +98,7 @@ def ensure_data_gitignore() -> None:
         # Make sure tables/ is in data/.gitignore
         with open(data_gitignore) as f:
             entries = set(line.strip() for line in f if line.strip())
-        
+
         if "tables/" not in entries:
             add_entry_to_file(data_gitignore, "tables/")
 
@@ -106,21 +106,21 @@ def ensure_data_gitignore() -> None:
 def add_to_data_gitignore(path: Path) -> None:
     """
     Add a path to the data/.gitignore file, creating it if it doesn't exist.
-    
+
     Args:
         path: The path to add to data/.gitignore
     """
     data_dir = Path("data")
     data_gitignore = data_dir / ".gitignore"
     path_str = str(path.relative_to(BASE_DIR))
-    
+
     # First ensure data/.gitignore exists
     ensure_data_gitignore()
-    
+
     # If path starts with "data/", remove that prefix
     if path_str.startswith("data/"):
         path_str = path_str[5:]  # Remove "data/" prefix
-    
+
     # Then add the path to data/.gitignore
     add_entry_to_file(data_gitignore, path_str)
 
@@ -129,7 +129,7 @@ def add_to_gitignore(path: Path) -> None:
     """
     Legacy function to add a path directly to .gitignore.
     This will be phased out in favor of add_to_data_gitignore.
-    
+
     Args:
         path: The path to add to .gitignore
     """

--- a/src/alcove/wildcards.py
+++ b/src/alcove/wildcards.py
@@ -1,0 +1,116 @@
+"""Expand wildcard steps (e.g. table://foo/*) into concrete per-version steps."""
+
+import graphlib
+
+from alcove.types import Dag, StepURI
+
+
+def expand_wildcards(dag: Dag) -> tuple[Dag, dict[str, list[str]]]:
+    """Expand wildcard step URIs into concrete per-version steps.
+
+    Returns (expanded_dag, wildcard_groups) where wildcard_groups maps
+    scheme://base_path to the list of discovered versions.
+    """
+    expanded: Dag = dict(dag)
+    wildcard_groups: dict[str, list[str]] = {}
+
+    # Process wildcard step keys in topological order so chained wildcards work
+    topo_order = list(graphlib.TopologicalSorter(expanded).static_order())
+    wildcard_keys = [s for s in topo_order if s in expanded and s.is_wildcard]
+
+    for wc_step in wildcard_keys:
+        wc_deps = expanded[wc_step]
+
+        # Discover versions: from the step's own base_path OR from its wildcard deps
+        versions = _discover_versions(wc_step, expanded)
+        if not versions:
+            # Try to discover versions from wildcard dependencies
+            for dep in wc_deps:
+                if dep.is_wildcard:
+                    dep_versions = _discover_versions(dep, expanded)
+                    if dep_versions:
+                        versions = dep_versions
+                        break
+
+        if not versions:
+            raise ValueError(
+                f"Wildcard step {wc_step} matched zero concrete versions"
+            )
+
+        group_key = f"{wc_step.scheme}://{wc_step.base_path}"
+        wildcard_groups[group_key] = sorted(versions)
+
+        # Also record wildcard groups for wildcard deps
+        for dep in wc_deps:
+            if dep.is_wildcard:
+                dep_key = f"{dep.scheme}://{dep.base_path}"
+                if dep_key not in wildcard_groups:
+                    dep_versions = _discover_versions(dep, expanded)
+                    if dep_versions:
+                        wildcard_groups[dep_key] = sorted(dep_versions)
+
+        # Create one concrete step per version
+        for v in versions:
+            concrete = wc_step.with_version(v)
+            concrete_deps = [
+                dep.with_version(v) if dep.is_wildcard else dep for dep in wc_deps
+            ]
+            expanded[concrete] = concrete_deps
+
+        del expanded[wc_step]
+
+    # Expand wildcard deps on concrete steps (e.g. summary/2025-02 depends on foo/*)
+    for step in list(expanded):
+        if step.is_wildcard:
+            continue
+        new_deps = []
+        for dep in expanded[step]:
+            if dep.is_wildcard:
+                dep_key = f"{dep.scheme}://{dep.base_path}"
+                if dep_key not in wildcard_groups:
+                    versions = _discover_versions(dep, expanded)
+                    if not versions:
+                        raise ValueError(
+                            f"Wildcard dependency {dep} on step {step} "
+                            f"matched zero concrete versions"
+                        )
+                    wildcard_groups[dep_key] = sorted(versions)
+
+                for v in wildcard_groups[dep_key]:
+                    new_deps.append(dep.with_version(v))
+            else:
+                new_deps.append(dep)
+        expanded[step] = new_deps
+
+    # Validate no wildcards remain
+    for step in expanded:
+        if step.is_wildcard:
+            raise ValueError(f"Wildcard step {step} was not expanded")
+        for dep in expanded[step]:
+            if dep.is_wildcard:
+                raise ValueError(f"Wildcard dep {dep} on {step} was not expanded")
+
+    return expanded, wildcard_groups
+
+
+def _discover_versions(wc_step: StepURI, dag: Dag) -> list[str]:
+    """Find all versions for a wildcard step by scanning the DAG for concrete
+    steps that share the same scheme and base_path."""
+    base = wc_step.base_path
+    scheme = wc_step.scheme
+    versions = set()
+
+    # Look at all steps (keys) in the DAG
+    for step in dag:
+        if step == wc_step:
+            continue
+        if step.scheme == scheme and step.base_path == base and not step.is_wildcard:
+            versions.add(step.version)
+
+    # Also look at deps for matching concrete URIs
+    for deps in dag.values():
+        for dep in deps:
+            if dep.scheme == scheme and dep.base_path == base and not dep.is_wildcard:
+                versions.add(dep.version)
+
+    return list(versions)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,19 +11,20 @@ def minio_container():
     """
     Start a MinIO container for testing, using the Docker SDK.
     Raises an exception if Docker is not available or container can't be started.
-    
+
     Uses the DOCKER_HOST environment variable if set to connect to the correct Docker context.
-    
+
     Skips container creation if running in GitHub Actions CI environment.
     """
     # Check if running in GitHub Actions CI
     is_github_ci = os.environ.get("GITHUB_ACTIONS") == "true"
-    
+
     # If in CI, we'll use the GitHub Actions service container instead
     if is_github_ci:
         print("Running in GitHub Actions CI - using GitHub-provided MinIO service")
         # Verify the CI-provided MinIO is available
         import socket
+
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             s.connect(("localhost", 9000))
@@ -33,18 +34,18 @@ def minio_container():
             pytest.fail(f"CI MinIO service not responding on port 9000: {conn_error}")
         yield None
         return
-    
+
     # Get Docker host from environment if available
     docker_host = os.environ.get("DOCKER_HOST")
     if docker_host:
         print(f"Using DOCKER_HOST: {docker_host}")
-    
+
     # Check for and clean up any existing container with our name
     container_name = "alcove-minio-test"
-    
+
     try:
         client = docker.from_env()
-        
+
         # Try to remove any existing container
         try:
             old_container = client.containers.get(container_name)
@@ -54,7 +55,7 @@ def minio_container():
             print(f"Removed existing container: {container_name}")
         except NotFound:
             pass  # Container doesn't exist, which is fine
-        
+
         # Create a new container
         container = client.containers.run(
             "minio/minio",
@@ -68,10 +69,10 @@ def minio_container():
             volumes={"/tmp/minio-data": {"bind": "/data", "mode": "rw"}},
             detach=True,
         )
-        
+
         # Wait for MinIO to be ready
         time.sleep(3)
-        
+
         # Create the test bucket using another container
         try:
             bucket_container = client.containers.get("alcove-createbucket")
@@ -79,21 +80,24 @@ def minio_container():
                 bucket_container.remove(force=True)
         except NotFound:
             pass
-            
+
         # Create the test bucket
         bucket_container = client.containers.run(
             "minio/mc",
             name="alcove-createbucket",
             entrypoint=["/bin/sh", "-c"],
-            command=[f"mc config host add myminio http://{container_name}:9000 justtesting justtesting && mc mb myminio/test -p || true"],
-            network_mode="default", 
+            command=[
+                f"mc config host add myminio http://{container_name}:9000 justtesting justtesting && mc mb myminio/test -p || true"
+            ],
+            network_mode="default",
             links={container_name: container_name},
             detach=False,
             remove=True,
         )
-        
+
         # Verify MinIO is actually responding
         import socket
+
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             s.connect(("localhost", 9000))
@@ -101,18 +105,18 @@ def minio_container():
             s.close()
         except Exception as conn_error:
             pytest.fail(f"MinIO container is not responding on port 9000: {conn_error}")
-        
+
         # Successfully initialized Docker
         print("Using Docker-managed MinIO for testing")
-        
+
         # Yield the container for the tests to use
         yield container
-        
+
         # Clean up after tests
         print("Cleaning up MinIO container")
         container.stop()
         container.remove()
-        
+
     except Exception as e:
         error_msg = f"Docker or MinIO not available: {str(e)}"
         pytest.fail(error_msg)
@@ -123,11 +127,11 @@ def setup_test_environment(tmp_path, minio_container):
     """
     Setup test environment with the MinIO container running.
     This replaces the fixtures in test_alcove.py and test_tables.py.
-    
+
     Uses the same configuration for both local testing and GitHub CI environment.
     """
     # If MinIO is required but not available, tests will have already failed through the minio_container fixture
-    
+
     # Setup test environment with consistent S3 credentials for both local and CI
     os.environ["TEST_ENVIRONMENT"] = "1"  # Enable test mode
     os.environ["S3_ACCESS_KEY"] = "justtesting"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -118,3 +118,57 @@ def test_names_both(alcove_with_tables):
     assert "ns_widgets_latest" in db.tables
     assert len(db.tables) > 2
     db.close()
+
+
+@pytest.fixture
+def alcove_with_wildcard_tables(tmp_path):
+    """Alcove with partitioned tables and a wildcard entry."""
+    os.chdir(tmp_path)
+
+    save_yaml(
+        {
+            "version": 1,
+            "data_dir": "data",
+            "steps": {
+                "table://costs/2025-02-17": [],
+                "table://costs/2025-02-18": [],
+                "table://costs/*": ["snapshot://raw/*"],
+            },
+        },
+        tmp_path / "alcove.yaml",
+    )
+
+    # Write partition parquet files
+    for version, vals in [
+        ("2025-02-17", {"dim_id": [1, 2], "amount": [10, 20]}),
+        ("2025-02-18", {"dim_id": [3, 4], "amount": [30, 40]}),
+    ]:
+        p = tmp_path / "data" / "tables" / "costs" / f"{version}.parquet"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        pl.DataFrame(vals).write_parquet(p)
+
+    return Alcove(tmp_path / "alcove.yaml")
+
+
+def test_union_view_queries_all_partitions(alcove_with_wildcard_tables):
+    db = AlcoveDB(alcove=alcove_with_wildcard_tables, names="full")
+    df = db.sql("costs")
+    assert len(df) == 4
+    assert set(df["dim_id"].to_list()) == {1, 2, 3, 4}
+    db.close()
+
+
+def test_individual_partition_views(alcove_with_wildcard_tables):
+    db = AlcoveDB(alcove=alcove_with_wildcard_tables, names="full")
+    df = db.sql("costs_20250217")
+    assert len(df) == 2
+    assert set(df["dim_id"].to_list()) == {1, 2}
+    db.close()
+
+
+def test_union_view_in_tables_list(alcove_with_wildcard_tables):
+    db = AlcoveDB(alcove=alcove_with_wildcard_tables, names="full")
+    assert "costs" in db.tables
+    assert "costs_20250217" in db.tables
+    assert "costs_20250218" in db.tables
+    db.close()

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -12,33 +12,33 @@ def test_gitignore_simple():
     with tempfile.TemporaryDirectory() as tmp:
         os.chdir(tmp)
         tmp_path = Path(tmp)
-        
+
         # Mock BASE_DIR to be our temporary directory
-        with mock.patch('alcove.utils.BASE_DIR', tmp_path):
+        with mock.patch("alcove.utils.BASE_DIR", tmp_path):
             # Create a temporary path structure
             data_dir = tmp_path / "data" / "test"
             data_dir.mkdir(parents=True)
             test_file = data_dir / "path"
             test_file.touch()
-            
+
             # Test with non-existent data/.gitignore
             add_to_gitignore(test_file)
-            
+
             # Check the file was created with the right entry
             data_gitignore_path = tmp_path / "data" / ".gitignore"
             assert data_gitignore_path.exists()
-            content = data_gitignore_path.read_text().strip().split('\n')
+            content = data_gitignore_path.read_text().strip().split("\n")
             assert "tables/" in content
             assert "test/path" in content  # path without "data/" prefix
-            
+
             # Test adding a second entry
             test_file2 = data_dir / "another" / "path"
             test_file2.parent.mkdir(parents=True)
             test_file2.touch()
             add_to_gitignore(test_file2)
-            
+
             # Check the new entry was added
-            content = data_gitignore_path.read_text().strip().split('\n')
+            content = data_gitignore_path.read_text().strip().split("\n")
             assert "tables/" in content
             assert "test/path" in content
             assert "test/another/path" in content
@@ -49,25 +49,25 @@ def test_gitignore_existing_entry():
     with tempfile.TemporaryDirectory() as tmp:
         os.chdir(tmp)
         tmp_path = Path(tmp)
-        
+
         # Mock BASE_DIR to be our temporary directory
-        with mock.patch('alcove.utils.BASE_DIR', tmp_path):
+        with mock.patch("alcove.utils.BASE_DIR", tmp_path):
             # Create data/.gitignore with existing entry
             data_dir = tmp_path / "data"
             data_dir.mkdir(parents=True)
             data_gitignore_path = data_dir / ".gitignore"
             data_gitignore_path.write_text("tables/\nexisting/entry\n")
-            
+
             # Create a file that matches the existing entry
             entry_path = tmp_path / "data" / "existing" / "entry"
             entry_path.parent.mkdir(parents=True)
             entry_path.touch()
-            
+
             # Try to add the same entry
             add_to_gitignore(entry_path)
-            
+
             # Check no duplicate was added
-            content = data_gitignore_path.read_text().strip().split('\n')
+            content = data_gitignore_path.read_text().strip().split("\n")
             assert len(content) == 2
             assert "tables/" in content
             assert "existing/entry" in content
@@ -77,20 +77,20 @@ def test_ensure_data_gitignore():
     """Test that ensure_data_gitignore works correctly"""
     with tempfile.TemporaryDirectory() as tmp:
         os.chdir(tmp)
-        
+
         # Test with non-existent data directory
         ensure_data_gitignore()
-        
+
         # Check the directories and file were created with the right entries
         data_dir = Path(tmp) / "data"
         data_gitignore_path = data_dir / ".gitignore"
-        
+
         assert data_dir.exists()
         assert data_gitignore_path.exists()
-        
+
         content = data_gitignore_path.read_text().strip()
         assert content == "tables/"
-        
+
         # Test idempotence - calling again shouldn't add duplicate
         ensure_data_gitignore()
         content = data_gitignore_path.read_text().strip()
@@ -102,81 +102,83 @@ def test_add_to_data_gitignore():
     with tempfile.TemporaryDirectory() as tmp:
         os.chdir(tmp)
         tmp_path = Path(tmp)
-        
+
         # Mock BASE_DIR to be our temporary directory
-        with mock.patch('alcove.utils.BASE_DIR', tmp_path):
+        with mock.patch("alcove.utils.BASE_DIR", tmp_path):
             # Create a test file
             data_dir = tmp_path / "data" / "test"
             data_dir.mkdir(parents=True)
             test_file = data_dir / "path"
             test_file.touch()
-            
+
             # Test with non-existent data/.gitignore
             add_to_data_gitignore(test_file)
-            
+
             # Check data/.gitignore was created with the right entries
             data_gitignore_path = tmp_path / "data" / ".gitignore"
-            
+
             assert data_gitignore_path.exists()
-            
-            data_gitignore_content = data_gitignore_path.read_text().strip().split('\n')
-            
+
+            data_gitignore_content = data_gitignore_path.read_text().strip().split("\n")
+
             # Should contain tables/ and test/path (without data/ prefix)
             assert "tables/" in data_gitignore_content
             assert "test/path" in data_gitignore_content
-            
+
             # Add another entry
             test_file2 = data_dir / "another" / "path"
             test_file2.parent.mkdir(parents=True)
             test_file2.touch()
             add_to_data_gitignore(test_file2)
-            
+
             # Check the new entry was added to data/.gitignore
-            data_gitignore_content = data_gitignore_path.read_text().strip().split('\n')
+            data_gitignore_content = data_gitignore_path.read_text().strip().split("\n")
             assert "tables/" in data_gitignore_content
             assert "test/path" in data_gitignore_content
             assert "test/another/path" in data_gitignore_content
-        
-        
+
+
 def test_audit_gitignore_setup():
     """Test that audit_gitignore_setup works correctly"""
     with tempfile.TemporaryDirectory() as tmp:
         os.chdir(tmp)
-        
+
         # Create a .gitignore with data file patterns
         gitignore_path = Path(tmp) / ".gitignore"
-        gitignore_path.write_text("data/snapshots/test/path\ndata/snapshots/another/path\nother/file\n")
-        
+        gitignore_path.write_text(
+            "data/snapshots/test/path\ndata/snapshots/another/path\nother/file\n"
+        )
+
         # Run audit with fix=True
         audit_gitignore_setup(fix=True)
-        
+
         # Check that data/.gitignore was created and contains the right patterns
         data_dir = Path(tmp) / "data"
         data_gitignore_path = data_dir / ".gitignore"
         assert data_gitignore_path.exists()
-        
+
         data_gitignore_content = data_gitignore_path.read_text().strip().split("\n")
         assert "tables/" in data_gitignore_content
         assert "snapshots/test/path" in data_gitignore_content
         assert "snapshots/another/path" in data_gitignore_content
-        
+
         # Check that .gitignore now only contains non-data patterns
         gitignore_content = gitignore_path.read_text().strip().split("\n")
         assert "other/file" in gitignore_content
         assert "data/snapshots/test/path" not in gitignore_content
         assert "data/snapshots/another/path" not in gitignore_content
-        
+
         # Test migration from .data-files to data/.gitignore
         # Create a .data-files file with some entries
         data_files_path = Path(tmp) / ".data-files"
         data_files_path.write_text("data/old/entry\ndata/another/old/entry\n")
-        
+
         # Run audit with fix=True again
         audit_gitignore_setup(fix=True)
-        
+
         # Check that .data-files was removed
         assert not data_files_path.exists()
-        
+
         # Check that data/.gitignore now contains both sets of entries
         data_gitignore_content = data_gitignore_path.read_text().strip().split("\n")
         assert "tables/" in data_gitignore_content

--- a/tests/test_wildcards.py
+++ b/tests/test_wildcards.py
@@ -1,0 +1,152 @@
+import pytest
+
+from alcove.types import StepURI
+from alcove.wildcards import expand_wildcards
+
+
+# ── StepURI wildcard properties ──────────────────────────────────────
+
+
+def test_is_wildcard():
+    assert StepURI("table", "foo/*").is_wildcard
+    assert not StepURI("table", "foo/2025-02-17").is_wildcard
+
+
+def test_base_path():
+    assert StepURI("table", "foo/*").base_path == "foo"
+    assert StepURI("table", "ns/foo/*").base_path == "ns/foo"
+    assert StepURI("table", "foo/2025-02-17").base_path == "foo"
+
+
+def test_version():
+    assert StepURI("table", "foo/*").version == "*"
+    assert StepURI("table", "foo/2025-02-17").version == "2025-02-17"
+
+
+def test_with_version():
+    uri = StepURI("table", "foo/*")
+    concrete = uri.with_version("2025-02-17")
+    assert concrete == StepURI("table", "foo/2025-02-17")
+    assert concrete.scheme == "table"
+
+
+# ── expand_wildcards ─────────────────────────────────────────────────
+
+
+def test_passthrough_no_wildcards():
+    """DAG without wildcards is returned unchanged."""
+    dag = {
+        StepURI("snapshot", "a/v1"): [],
+        StepURI("table", "b/v1"): [StepURI("snapshot", "a/v1")],
+    }
+    expanded, groups = expand_wildcards(dag)
+    assert expanded == dag
+    assert groups == {}
+
+
+def test_simple_expansion():
+    """table://foo/* with snapshot://bar/* expands to per-version steps."""
+    dag = {
+        StepURI("snapshot", "bar/2025-02-17"): [],
+        StepURI("snapshot", "bar/2025-02-18"): [],
+        StepURI("table", "foo/*"): [StepURI("snapshot", "bar/*")],
+    }
+    expanded, groups = expand_wildcards(dag)
+
+    # Wildcard key removed
+    assert StepURI("table", "foo/*") not in expanded
+
+    # Concrete keys created
+    assert StepURI("table", "foo/2025-02-17") in expanded
+    assert StepURI("table", "foo/2025-02-18") in expanded
+
+    # Dependencies are concrete
+    assert expanded[StepURI("table", "foo/2025-02-17")] == [
+        StepURI("snapshot", "bar/2025-02-17")
+    ]
+    assert expanded[StepURI("table", "foo/2025-02-18")] == [
+        StepURI("snapshot", "bar/2025-02-18")
+    ]
+
+    # Groups recorded
+    assert "table://foo" in groups
+    assert sorted(groups["table://foo"]) == ["2025-02-17", "2025-02-18"]
+
+
+def test_chained_wildcards():
+    """a/* → b/* → c/* all expand correctly."""
+    dag = {
+        StepURI("snapshot", "c/v1"): [],
+        StepURI("snapshot", "c/v2"): [],
+        StepURI("table", "b/*"): [StepURI("snapshot", "c/*")],
+        StepURI("table", "a/*"): [StepURI("table", "b/*")],
+    }
+    expanded, groups = expand_wildcards(dag)
+
+    # All wildcards removed
+    for step in expanded:
+        assert not step.is_wildcard
+
+    # Check chain
+    assert expanded[StepURI("table", "a/v1")] == [StepURI("table", "b/v1")]
+    assert expanded[StepURI("table", "a/v2")] == [StepURI("table", "b/v2")]
+    assert expanded[StepURI("table", "b/v1")] == [StepURI("snapshot", "c/v1")]
+    assert expanded[StepURI("table", "b/v2")] == [StepURI("snapshot", "c/v2")]
+
+
+def test_concrete_to_wildcard():
+    """A concrete step depending on foo/* gets all partitions as deps."""
+    dag = {
+        StepURI("snapshot", "bar/v1"): [],
+        StepURI("snapshot", "bar/v2"): [],
+        StepURI("table", "foo/*"): [StepURI("snapshot", "bar/*")],
+        StepURI("table", "summary/2025-02"): [StepURI("table", "foo/*")],
+    }
+    expanded, groups = expand_wildcards(dag)
+
+    summary_deps = expanded[StepURI("table", "summary/2025-02")]
+    assert StepURI("table", "foo/v1") in summary_deps
+    assert StepURI("table", "foo/v2") in summary_deps
+
+
+def test_mixed_deps():
+    """Wildcard + concrete deps on the same step."""
+    dag = {
+        StepURI("snapshot", "bar/v1"): [],
+        StepURI("snapshot", "bar/v2"): [],
+        StepURI("table", "foo/*"): [StepURI("snapshot", "bar/*")],
+        StepURI("table", "report/latest"): [
+            StepURI("table", "foo/*"),
+            StepURI("snapshot", "bar/v1"),
+        ],
+    }
+    expanded, groups = expand_wildcards(dag)
+
+    report_deps = expanded[StepURI("table", "report/latest")]
+    # Should have foo/v1, foo/v2, and bar/v1
+    assert StepURI("table", "foo/v1") in report_deps
+    assert StepURI("table", "foo/v2") in report_deps
+    assert StepURI("snapshot", "bar/v1") in report_deps
+
+
+def test_wildcard_zero_versions_raises():
+    """Wildcard with no matching versions raises an error."""
+    dag = {
+        StepURI("table", "foo/*"): [StepURI("snapshot", "bar/*")],
+    }
+    with pytest.raises(ValueError, match="zero concrete versions"):
+        expand_wildcards(dag)
+
+
+def test_wildcard_versions_from_deps():
+    """Versions discovered from deps of other steps, not just step keys."""
+    dag = {
+        StepURI("snapshot", "data/v1"): [],
+        StepURI("snapshot", "data/v2"): [],
+        StepURI("table", "clean/*"): [StepURI("snapshot", "data/*")],
+    }
+    expanded, groups = expand_wildcards(dag)
+
+    assert StepURI("table", "clean/v1") in expanded
+    assert StepURI("table", "clean/v2") in expanded
+    assert sorted(groups["table://clean"]) == ["v1", "v2"]

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ dev = [
     { name = "pytest-docker" },
     { name = "ruff" },
     { name = "twine" },
+    { name = "zensical" },
 ]
 
 [package.metadata]
@@ -53,6 +54,7 @@ dev = [
     { name = "pytest-docker", specifier = ">=2.0.0" },
     { name = "ruff", specifier = ">=0.7.2" },
     { name = "twine", specifier = ">=6.1.0" },
+    { name = "zensical", specifier = ">=0.0.23" },
 ]
 
 [[package]]
@@ -203,6 +205,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -238,6 +252,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/33/c1cf182c152e1d262cac56850939530c05ca6c8d149aa0dcee490b417e99/cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23", size = 4193906, upload-time = "2025-03-02T00:00:56.49Z" },
     { url = "https://files.pythonhosted.org/packages/e1/99/87cf26d4f125380dc674233971069bc28d19b07f7755b29861570e513650/cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922", size = 4081572, upload-time = "2025-03-02T00:00:59.995Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/6a3e0391957cc0c5f84aef9fbdd763035f2b52e998a53f99345e3ac69312/cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4", size = 4298631, upload-time = "2025-03-02T00:01:01.623Z" },
+]
+
+[[package]]
+name = "deepmerge"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
 ]
 
 [[package]]
@@ -425,6 +448,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload-time = "2024-12-25T15:26:45.782Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085, upload-time = "2024-12-25T15:26:44.377Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -630,6 +662,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905, upload-time = "2024-05-04T13:42:02.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513, upload-time = "2024-05-04T13:41:57.345Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
 ]
 
 [[package]]
@@ -956,4 +1001,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
+]
+
+[[package]]
+name = "zensical"
+version = "0.0.23"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "deepmerge" },
+    { name = "markdown" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ab/a65452b4e769552fd5a78c4996d6cf322630d896ddfd55c5433d96485e8b/zensical-0.0.23.tar.gz", hash = "sha256:5c4fc3aaf075df99d8cf41b9f2566e4d588180d9a89493014d3607dfe50ac4bc", size = 3822451, upload-time = "2026-02-11T21:24:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/86/035aa02bd36d26a03a1885bc22a73d4fe61ba0e21d0033cc42baf13d24f6/zensical-0.0.23-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:35d6d3eb803fe73a67187a1a25443408bd02a8dd50e151f4a4bafd40de3f0928", size = 12242966, upload-time = "2026-02-11T21:24:05.894Z" },
+    { url = "https://files.pythonhosted.org/packages/be/68/335dfbb7efc972964f0610736a0ad243dd8a5dcc2ec76b9ddb84c847a4a4/zensical-0.0.23-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:5973267460a190f348f24d445ff0c01e8ed334fd075947687b305e68257f6b18", size = 12125173, upload-time = "2026-02-11T21:24:08.507Z" },
+    { url = "https://files.pythonhosted.org/packages/25/9c/d567da04fbeb077df5cf06a94f947af829ebef0ff5ca7d0ba4910a6cbdf6/zensical-0.0.23-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:953adf1f0b346a6c65fc6e05e6cc1c38a6440fec29c50c76fb29700cc1927006", size = 12489636, upload-time = "2026-02-11T21:24:10.91Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6e/481a3ecf8a7b63a35c67f5be1ea548185d55bb1dacead54f76a9550197b2/zensical-0.0.23-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49c1cbd6131dafa056be828e081759184f9b8dd24b99bf38d1e77c8c31b0c720", size = 12421313, upload-time = "2026-02-11T21:24:13.9Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/aa/a95481547f708432636f5f8155917c90d877c244c62124a084f7448b60b2/zensical-0.0.23-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5b7fe22c5d33b2b91899c5df7631ad4ce9cccfabac2560cc92ba73eafe2d297", size = 12761031, upload-time = "2026-02-11T21:24:17.016Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/9f/ce1c5af9afd11fe3521a90441aba48c484f98730c6d833d69ee4387ae2e9/zensical-0.0.23-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a3679d6bf6374f503afb74d9f6061da5de83c25922f618042b63a30b16f0389", size = 12527415, upload-time = "2026-02-11T21:24:19.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/13a5d4d99f3b77e7bf4e791ef991a611ca2f108ed7eddf20858544ab0a91/zensical-0.0.23-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54d981e21a19c3dcec6e7fa77c4421db47389dfdff20d29fea70df8e1be4062e", size = 12665352, upload-time = "2026-02-11T21:24:22.703Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/84/3d0a187ed941826ca26b19a661c41685d8017b2a019afa0d353eb2ebbdba/zensical-0.0.23-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:afde7865cc3c79c99f6df4a911d638fb2c3b472a1b81367d47163f8e3c36f910", size = 12689042, upload-time = "2026-02-11T21:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/65/12466408f428f2cf7140b32d484753db0891debae3c956f4c076b51eeb17/zensical-0.0.23-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c484674d7b0a3e6d39db83914db932249bccdef2efaf8a5669671c66c16f584d", size = 12834779, upload-time = "2026-02-11T21:24:28.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ab/0771ac6ffb30e4f04c20374e3beca9e71c3f81112219cdbd86cdc0e3d337/zensical-0.0.23-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:927d12fe2851f355fb3206809e04641d6651bdd2ff4afe9c205721aa3a32aa82", size = 12797057, upload-time = "2026-02-11T21:24:31.383Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ce/fbd45c00a1cba15508ea3c29b121b4be010254eb65c1512bf11f4478496c/zensical-0.0.23-cp310-abi3-win32.whl", hash = "sha256:ffb79db4244324e9cc063d16adff25a40b145153e5e76d75e0012ba3c05af25d", size = 11837823, upload-time = "2026-02-11T21:24:33.869Z" },
+    { url = "https://files.pythonhosted.org/packages/37/82/0aebaa8e7d2e6314a85d9b7ff3f7fc74837a94086b56a9d5d8f2240e9b9c/zensical-0.0.23-cp310-abi3-win_amd64.whl", hash = "sha256:a8cfe240dca75231e8e525985366d010d09ee73aec0937930e88f7230694ce01", size = 12036837, upload-time = "2026-02-11T21:24:36.163Z" },
 ]


### PR DESCRIPTION
Support snapshot and table steps with wildcards, which indicate date partitioning.

Date partitioning allows you to incrementally pull data from an upstream source, without re-storing or re-snapshotting the entire history each time. It's an essential feature if you intend to use alcove as a daily ETL.

This PR also adds docs that explain more about the site and the date parititioning feaures
